### PR TITLE
Remove Solr adapter's dependency on Postgresql

### DIFF
--- a/lib/valkyrie/persistence/solr.rb
+++ b/lib/valkyrie/persistence/solr.rb
@@ -11,7 +11,6 @@ end
 module Valkyrie::Persistence
   # Implements the DataMapper Pattern to store metadata into Solr
   module Solr
-    require 'valkyrie/persistence/postgres/metadata_adapter'
     require 'valkyrie/persistence/solr/metadata_adapter'
     require 'valkyrie/persistence/solr/composite_indexer'
   end


### PR DESCRIPTION
This require appears to just be in error. It was re-added to support a deprecation, which is now removed.