### PR TITLE
Permits additional arguments for the Valkyrie::Storage adapter method #upload

### DIFF
--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     resource = Valkyrie::Specs::CustomResource.new(id: "test")
     sha1 = Digest::SHA1.file(file).to_s
     size = file.size
-    expect(uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource)).to be_kind_of Valkyrie::StorageAdapter::File
+    expect(uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource, fake_upload_argument: true)).to be_kind_of Valkyrie::StorageAdapter::File
 
     expect(uploaded_file).to respond_to(:checksum).with_keywords(:digests)
     expect(uploaded_file).to respond_to(:valid?).with_keywords(:size, :digests)

--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -12,8 +12,9 @@ module Valkyrie::Storage
     # @param file [IO]
     # @param original_filename [String]
     # @param resource [Valkyrie::Resource]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::File]
-    def upload(file:, original_filename:, resource: nil)
+    def upload(file:, original_filename:, resource: nil, **_extra_arguments)
       new_path = path_generator.generate(resource: resource, file: file, original_filename: original_filename)
       FileUtils.mkdir_p(new_path.parent)
       file_mover.call(file.path, new_path)

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -31,8 +31,9 @@ module Valkyrie::Storage
     # @param file [IO]
     # @param original_filename [String]
     # @param resource [Valkyrie::Resource]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
-    def upload(file:, original_filename:, resource:)
+    def upload(file:, original_filename:, resource:, **_extra_arguments)
       identifier = id_to_uri(resource.id) + '/original'
       sha1 = fedora_version == 5 ? "sha" : "sha1"
       connection.http.put do |request|

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -13,8 +13,9 @@ module Valkyrie::Storage
     # @param file [IO]
     # @param original_filename [String]
     # @param resource [Valkyrie::Resource]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
-    def upload(file:, original_filename:, resource: nil)
+    def upload(file:, original_filename:, resource: nil, **_extra_arguments)
       identifier = Valkyrie::ID.new("memory://#{resource.id}")
       cache[identifier] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file)
     end


### PR DESCRIPTION
Ports the work introduced by @tpendragon to permit additional arguments for the Valkyrie::Storage adapter method #uploadts for the Valkyrie::Storage adapter method #upload

Resolves #705 