### PR TITLE
add parameter to pass in custom id_transformer to upload

### DIFF
--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -32,11 +32,11 @@ module Valkyrie::Storage
     # @param file [IO]
     # @param original_filename [String]
     # @param resource [Valkyrie::Resource]
+    # @param id_transformer [Lambda] transforms a simple id (e.g. 'DDS78RK') into a uri
     # @param extra_arguments [Hash] additional arguments which may be passed to other adapters
-    # @option id_transformer [Lambda] transforms a simple id (e.g. 'DDS78RK') into a uri
     # @return [Valkyrie::StorageAdapter::StreamFile]
-    def upload(file:, original_filename:, resource:, content_type: "application/octet-stream", **extra_arguments)
-      identifier = id_to_uri(resource.id, id_transformer: id_transformer(extra_arguments)) + '/original'
+    def upload(file:, original_filename:, resource:, content_type: "application/octet-stream", id_transformer: default_id_transformer, **extra_arguments)
+      identifier = id_to_uri(resource.id, id_transformer: id_transformer) + '/original'
       sha1 = fedora_version == 5 ? "sha" : "sha1"
       connection.http.put do |request|
         request.url identifier
@@ -97,10 +97,6 @@ module Valkyrie::Storage
         response = connection.http.get(fedora_identifier(id: id))
         raise Valkyrie::StorageAdapter::FileNotFound unless response.success?
         IOProxy.new(response.body)
-      end
-
-      def id_transformer(extra_arguments)
-        extra_arguments[:id_transformer] || default_id_transformer
       end
 
       def default_id_transformer

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -38,7 +38,7 @@ module Valkyrie::Storage
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource:, content_type: "application/octet-stream", # rubocop:disable Metrics/ParameterLists
                resource_uri_transformer: default_resource_uri_transformer, **_extra_arguments)
-      identifier = resource_uri_transformer.call(resource) + '/original'
+      identifier = resource_uri_transformer.call(resource, base_url) + '/original'
       sha1 = fedora_version == 5 ? "sha" : "sha1"
       connection.http.put do |request|
         request.url identifier
@@ -93,12 +93,16 @@ module Valkyrie::Storage
       end
 
       def default_resource_uri_transformer
-        lambda do |resource|
+        lambda do |resource, base_url|
           id = CGI.escape(resource.id.to_s)
-          pre_divider = base_path.starts_with?(SLASH) ? '' : SLASH
-          post_divider = base_path.ends_with?(SLASH) ? '' : SLASH
-          RDF::URI.new("#{connection.http.url_prefix}#{pre_divider}#{base_path}#{post_divider}#{id}")
+          RDF::URI.new(base_url + id)
         end
+      end
+
+      def base_url
+        pre_divider = base_path.starts_with?(SLASH) ? '' : SLASH
+        post_divider = base_path.ends_with?(SLASH) ? '' : SLASH
+        "#{connection.http.url_prefix}#{pre_divider}#{base_path}#{post_divider}"
       end
   end
 end

--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -143,14 +143,14 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
           )
         end
         let(:uri_transformer) do
-          lambda do |resource|
+          lambda do |resource, base_url|
             id = CGI.escape(resource.id.to_s)
             head = id.split('/').first
             head.gsub!(/#.*/, '')
-            RDF::URI.new("http://localhost:8998/rest/test/" + (head.scan(/..?/).first(4) + [id]).join('/'))
+            RDF::URI.new(base_url + (head.scan(/..?/).first(4) + [id]).join('/'))
           end
         end
-        let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: '/', fedora_version: 5)) }
+        let(:storage_adapter) { described_class.new(fedora_adapter_config(base_path: 'test', fedora_version: 5)) }
 
         it 'produces a valid URI' do
           expected_uri = 'fedora://localhost:8998/rest/test/AN/1D/4U/HA/AN1D4UHA/original'


### PR DESCRIPTION
Fixes: #736

The #id_to_uri method is only tested under Fedora 5.  There are no differences in how this method performs based on fedora version. 

## How much should the id_transformer do?

By using the id_transformer without passing any additional information, the passed in transformer needs to handle connection and basepath.  This effectively means the connection and basepath provided when the storage adapter was created are ignored.

### ALTERNATIVES: 

**OPTION 1:** Leave as is and let the caller handle the full translation (the code already in Hyrax does this)
**OPTION 2:** Make the id_transformer have signature (id, connection_prefix, basepath).  The transformer needs to know how to construct the first part of the path from these.
**OPTION 3:** Have the fedora storage adapter construct the first part of the path from connection_prefix and basepath.  The tranformer only effects transformation of the id.