### PR TITLE
Use samvera/fcrepo4 docker images instead of nulib/fcrepo4

### DIFF
--- a/.docker-stack/valkyrie-development/docker-compose.yml
+++ b/.docker-stack/valkyrie-development/docker-compose.yml
@@ -8,13 +8,13 @@ volumes:
   solr_index:
 services:
   fedora4:
-    image: nulib/fcrepo4:4.7.5
+    image: samvera/fcrepo4:4.7.5
     volumes:
     - fedora4:/data
     ports:
     - 8986:8080
   fedora5:
-    image: nulib/fcrepo4:5.1.0
+    image: samvera/fcrepo4:5.1.0
     volumes:
     - fedora5:/data
     ports:

--- a/.docker-stack/valkyrie-test/docker-compose.yml
+++ b/.docker-stack/valkyrie-test/docker-compose.yml
@@ -8,13 +8,13 @@ volumes:
   solr_index:
 services:
   fedora4:
-    image: nulib/fcrepo4:4.7.5
+    image: samvera/fcrepo4:4.7.5
     volumes:
     - fedora4:/data
     ports:
     - 8988:8080
   fedora5:
-    image: nulib/fcrepo4:5.1.0
+    image: samvera/fcrepo4:5.1.0
     volumes:
     - fedora5:/data
     ports:


### PR DESCRIPTION
Moving `fcrepo4` docker images out of the `nulib` namespace and into the `samvera` namespace