### PR TITLE
Define setters when building a Resource schema with `.attributes`

### DIFF
--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -14,6 +14,25 @@ RSpec.describe Valkyrie::Resource do
   subject(:resource) { Resource.new }
   let(:resource_klass) { Resource }
   it_behaves_like "a Valkyrie::Resource"
+
+  describe '.attributes' do
+    let(:schema) { { attr1: Valkyrie::Types::String, attr2: Valkyrie::Types::Set } }
+
+    it 'defines new attributes' do
+      expect { Resource.attributes(schema) }
+        .to change { Resource.fields }
+        .to include(:attr1, :attr2)
+    end
+
+    it 'defines setters for attributes' do
+      Resource.attributes(schema)
+
+      expect { resource.attr1 = 'moomin' }
+        .to change { resource.attr1 }
+        .to eq 'moomin'
+    end
+  end
+
   describe "#fields" do
     it "returns all configured fields as an array of symbols" do
       expect(Resource.fields).to contain_exactly :id, :internal_resource, :created_at, :updated_at, :title


### PR DESCRIPTION
Fixes #760.

`Dry::Struct` sets attributes using the `.attributes` class method. Calls to the
individual `.attribute` configuration method pass through to there. In some
cases, it's desirable to setup many attributes at once, by directly calling
`.attributes`.

The various checks we add in `Valkyrie::Resource.attribute` are missed for users
who take advantage of this lowel level schema setup. This fixes one of those
cases, by ensuring valkyrie-style attribute setters get built for all
attributes, regardless of whether they were setup individually or as part of a
schema.

Several other fixes can be considered by moving `raise` and `:member_ids` type
casting down into this method as well.