### PR TITLE
Don't merge postgres attributes, just overwrite them.

### DIFF
--- a/lib/valkyrie/persistence/postgres/resource_converter.rb
+++ b/lib/valkyrie/persistence/postgres/resource_converter.rb
@@ -20,7 +20,7 @@ module Valkyrie::Persistence::Postgres
         orm_object.internal_resource = resource.internal_resource
         process_lock_token(orm_object)
         orm_object.disable_optimistic_locking! unless resource.optimistic_locking_enabled?
-        orm_object.metadata.merge!(attributes)
+        orm_object.metadata = attributes
       end
     end
 

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -56,6 +56,14 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     output = persister.save(resource: resource)
 
     expect(output.single_value).to eq "A single value"
+
+    reloaded = query_service.find_by(id: output.id)
+
+    reloaded.single_value = nil
+    persister.save(resource: reloaded)
+    reloaded = query_service.find_by(id: reloaded.id)
+
+    expect(reloaded.single_value).to eq nil
   end
 
   it "returns nil for an unset single value" do


### PR DESCRIPTION
Closes #767

We've been doing this in valkyrie-sequel the entire time and have had no
issues in Figgy. It's more performant, and there's no reason to do a
merge of the existing metadata.