### PR TITLE
Use a DEFAULT_FEDORA_VERSION constant for the Fedora adapter

### DIFF
--- a/lib/valkyrie/persistence/fedora.rb
+++ b/lib/valkyrie/persistence/fedora.rb
@@ -19,5 +19,7 @@ module Valkyrie::Persistence
     require 'valkyrie/persistence/fedora/ordered_list'
     require 'valkyrie/persistence/fedora/ordered_reader'
     require 'valkyrie/persistence/fedora/list_node'
+
+    DEFAULT_FEDORA_VERSION = 5
   end
 end

--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -15,7 +15,7 @@ module Valkyrie::Persistence::Fedora
     # @param [String] base_path
     # @param [Valkyrie::Persistence::Fedora::PermissiveSchema] schema
     # @param [Integer] fedora_version
-    def initialize(connection:, base_path: "/", schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new, fedora_version: 5)
+    def initialize(connection:, base_path: "/", schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new, fedora_version: Valkyrie::Persistence::Fedora::DEFAULT_FEDORA_VERSION)
       @connection = connection
       @base_path = base_path
       @schema = schema

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -7,7 +7,7 @@ module Valkyrie::Storage
     SLASH = '/'
 
     # @param [Ldp::Client] connection
-    def initialize(connection:, base_path: "/", fedora_version: 5)
+    def initialize(connection:, base_path: "/", fedora_version: Valkyrie::Persistence::Fedora::DEFAULT_FEDORA_VERSION)
       @connection = connection
       @base_path = base_path
       @fedora_version = fedora_version


### PR DESCRIPTION
Introduce `DEFAULT_FEDORA_VERSION` and set it to 5.

Closes #720.