### PR TITLE
Fixes #622: Valkyrie ID should equal string equivalent of ID to string

### DIFF
--- a/lib/valkyrie/id.rb
+++ b/lib/valkyrie/id.rb
@@ -17,7 +17,8 @@ module Valkyrie
     delegate :hash, to: :state
 
     def eql?(other)
-      other.class == self.class && other.state == state
+      (other.class == self.class && other.state == state) ||
+      (other.to_s == self.to_s)
     end
     alias == eql?
 

--- a/lib/valkyrie/id.rb
+++ b/lib/valkyrie/id.rb
@@ -18,7 +18,7 @@ module Valkyrie
 
     def eql?(other)
       (other.class == self.class && other.state == state) ||
-      (other.to_s == self.to_s)
+        (other.to_s == to_s)
     end
     alias == eql?
 

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Valkyrie::Types do
       it 'casts to a string' do
         expect(resource.thumbnail_id).to eq Valkyrie::ID.new('123')
       end
+
+      it 'equals the equivalent string if ID matches string' do
+        expect(resource.thumbnail_id).to eq Valkyrie::ID.new('123')
+      end
     end
 
     context 'when an ID is passed in' do

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Valkyrie::Types do
       end
 
       it 'equals the equivalent string if ID matches string' do
-        expect(resource.thumbnail_id).to eq Valkyrie::ID.new('123')
+        expect(resource.thumbnail_id).to eq '123'
       end
     end
 


### PR DESCRIPTION
Fixes Issue #622 (seems to be tagging the release, see: https://github.com/samvera/valkyrie/issues/662)

Valkyrie::ID#eql? and == should return true when a string is compared with an equivalent Valkyrie::ID

Added test to verify this behavior. The following examples should work per the example:

```
[11] pry(main)> id = Valkyrie::ID.new('abc')
=> #<Valkyrie::ID:0x007fdee25d4760 @id="abc">
[12] pry(main)> id.eql?('abc')
=> true
[13] pry(main)> id == 'abc'
=> true
[14] pry(main)> id == 'def'
=> false
[15] pry(main)> id == Valkyrie::ID.new('abc')
=> true
```

Following tests should pass: `bundle exec rspec spec/valkyrie/types_spec.rb` should verify this behavior.

Note: I just submitted my Individual Contributors License Agreement to Samvera Legal so not sure how long it takes to verify.