### PR TITLE
Remove unused database tables.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,18 +15,6 @@ ActiveRecord::Schema.define(version: 20170531004548) do
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "bookmarks", id: :serial, force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "user_type"
-    t.string "document_id"
-    t.string "document_type"
-    t.binary "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["document_id"], name: "index_bookmarks_on_document_id"
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
-  end
-
   create_table "orm_resources", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", null: false
@@ -34,32 +22,4 @@ ActiveRecord::Schema.define(version: 20170531004548) do
     t.string "internal_resource"
     t.index ["metadata"], name: "index_orm_resources_on_metadata", using: :gin
   end
-
-  create_table "searches", id: :serial, force: :cascade do |t|
-    t.binary "query_params"
-    t.integer "user_id"
-    t.string "user_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_searches_on_user_id"
-  end
-
-  create_table "users", id: :serial, force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "guest", default: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  end
-
 end


### PR DESCRIPTION
Fixes #773 

Directly removes the bookmarks, users, and searches tables from the db/schema.rb.  They are not used and their presence is confusing.