### PR TITLE
Adds aliases for Valkyrie::Types::Relation and

### DIFF
--- a/lib/valkyrie/types.rb
+++ b/lib/valkyrie/types.rb
@@ -99,6 +99,8 @@ module Valkyrie
     end
     Array.singleton_class.include(ArrayDefault)
     Set.singleton_class.include(ArrayDefault)
+    Relation = Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+    OrderedRelation = Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)
 
     # Used for when an input may be an array, but the output needs to be a
     # single string.

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Valkyrie::Types do
       attribute :nested_resource_array, Valkyrie::Types::Array.of(Resource.optional)
       attribute :nested_resource_array_of, Valkyrie::Types::Array.of(Resource.optional)
       attribute :nested_resource_set, Valkyrie::Types::Set.of(Resource.optional)
+      attribute :relation_values, Valkyrie::Types::Relation
+      attribute :ordered_relation_values, Valkyrie::Types::OrderedRelation
     end
   end
   after do
@@ -140,6 +142,41 @@ RSpec.describe Valkyrie::Types do
     it "returns the boolean value set" do
       resource = Resource.new(my_flag: true)
       expect(resource.my_flag).to be true
+    end
+  end
+
+  describe "the Relation type" do
+    context "acts as a Set of Valkyrie::Types::ID" do
+      it "can contain IDs" do
+        resource = Resource.new(relation_values: [Valkyrie::ID.new("1"), nil, Valkyrie::ID.new("A"), Valkyrie::ID.new("")])
+        expect(resource.relation_values).to contain_exactly Valkyrie::ID.new("1"), Valkyrie::ID.new("A")
+      end
+
+      it "casts values to ID type" do
+        resource = Resource.new(relation_values: [1, "ducks"])
+        expect(resource.relation_values).to contain_exactly Valkyrie::ID.new("1"), Valkyrie::ID.new("ducks")
+      end
+    end
+  end
+
+  describe "the OrderedRelation type" do
+    context "acts as an ordered Array of Valkyrie::Types::ID" do
+      it "can contain IDs" do
+        resource = Resource.new(ordered_relation_values: [Valkyrie::ID.new("1"), Valkyrie::ID.new("A")])
+        expect(resource.ordered_relation_values).to contain_exactly Valkyrie::ID.new("1"), Valkyrie::ID.new("A")
+      end
+
+      it "casts values to ID type" do
+        resource = Resource.new(ordered_relation_values: [1, "ducks"])
+        expect(resource.ordered_relation_values).to contain_exactly Valkyrie::ID.new("1"), Valkyrie::ID.new("ducks")
+      end
+
+      it "returns all values in order including duplicates" do
+        dup = Valkyrie::ID.new("1")
+        uniq = Valkyrie::ID.new("A")
+        resource = Resource.new(ordered_relation_values: [dup, uniq, dup])
+        expect(resource.ordered_relation_values).to contain_exactly dup, uniq, dup
+      end
     end
   end
 end


### PR DESCRIPTION
Valkyrie::Types::OrderedRelation in lib/valkyrie/types.rb

 Co-authored-by: Greg Luis <gregorio.luisramirez@oregonstate.edu>
 Co-authored-by: Linda Sato <lsato@uoregon.edu>
 Co-authored-by: Henry Neels <foglaboratories@gmail.com>

fixes #651