### PR TITLE
Fixes #683 - Raise an error when unable to find a StorageAdapter

### DIFF
--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -5,6 +5,7 @@ module Valkyrie
   #  storage backends (such as fedora, disk, etc)
   class StorageAdapter
     class FileNotFound < StandardError; end
+    class AdapterNotFoundError < StandardError; end
     class_attribute :storage_adapters
     self.storage_adapters = {}
     class << self
@@ -54,10 +55,12 @@ module Valkyrie
       # @param id [Valkyrie::ID]
       # @return [Valkyrie::StorageAdapter]
       def adapter_for(id:)
-        # TODO: Determine the appropriate response when we have an unhandled :id
-        storage_adapters.values.find do |storage_adapter|
+        handler = storage_adapters.values.find do |storage_adapter|
           storage_adapter.handles?(id: id)
         end
+
+        raise AdapterNotFoundError, 'Unable to find a StorageAdapter' if handler.nil?
+        handler
       end
     end
 

--- a/spec/valkyrie/storage_adapter_spec.rb
+++ b/spec/valkyrie/storage_adapter_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe Valkyrie::StorageAdapter do
 
       expect(described_class.adapter_for(id: file.id)).to eq storage_adapter
     end
+
+    it "raises an exception if unable to find a StorageAdapter" do
+      file = instance_double(Valkyrie::StorageAdapter::StreamFile, id: "yo")
+      described_class.register(storage_adapter, :find_test)
+
+      expect { described_class.adapter_for(id: file.id) }.to raise_error(Valkyrie::StorageAdapter::AdapterNotFoundError)
+    end
   end
 
   describe ".delete" do


### PR DESCRIPTION
Raise an error when unable to find a StorageAdapter 

Fixes #683 