### PR TITLE
Allow property for find_inverse_reference_by to be ordered and unordered in related object

### DIFF
--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -120,9 +120,10 @@ module Valkyrie::Persistence::Fedora
       raise ArgumentError, "Provide resource or id" unless resource || id
       ensure_persisted(resource) if resource
       resource ||= find_by(id: id)
-      ids = find_inverse_references_by_ordered(resource: resource, property: property)
-      ids += find_inverse_references_by_unordered(resource: resource, property: property)
-      ids.lazy.map { |ref_id| find_by(id: ref_id) }
+      ids = find_inverse_reference_ids_by_unordered(resource: resource, property: property).uniq
+      objects_from_unordered = ids.lazy.map { |ref_id| find_by(id: ref_id) }
+      objects_from_ordered = find_inverse_references_by_ordered(resource: resource, property: property, ignore_ids: ids)
+      [objects_from_unordered, objects_from_ordered].lazy.flat_map(&:lazy)
     end
 
     # (see Valkyrie::Persistence::Memory::QueryService#custom_queries)
@@ -132,19 +133,18 @@ module Valkyrie::Persistence::Fedora
 
     private
 
-      def find_inverse_references_by_unordered(resource:, property:)
+      def find_inverse_reference_ids_by_unordered(resource:, property:)
         content = content_with_inbound(id: resource.id)
         property_uri = adapter.schema.predicate_for(property: property, resource: nil)
-        ids = content.graph.query([nil, property_uri, adapter.id_to_uri(resource.id)]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
-        ids.uniq!
-        ids
+        content.graph.query([nil, property_uri, adapter.id_to_uri(resource.id)]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
       end
 
-      def find_inverse_references_by_ordered(resource:, property:)
+      def find_inverse_references_by_ordered(resource:, property:, ignore_ids: [])
         content = content_with_inbound(id: resource.id)
         ids = content.graph.query([nil, ::RDF::Vocab::ORE.proxyFor, adapter.id_to_uri(resource.id)]).map(&:subject).map { |x| x.to_s.gsub(/#.*/, '') }.map { |x| adapter.uri_to_id(x) }
         ids.uniq!
-        ids
+        ids.delete_if { |id| ignore_ids.include? id }
+        ids.lazy.map { |id| find_by(id: id) }.select { |o| o[property].include?(resource.id) }
       end
 
       # Ensures that an object is (or can be cast into a) Valkyrie::ID
@@ -171,10 +171,6 @@ module Valkyrie::Persistence::Fedora
       # @raise [ArgumentError]
       def ensure_persisted(resource)
         raise ArgumentError, 'resource is not saved' unless resource.persisted?
-      end
-
-      def ordered_property?(resource:, property:)
-        resource.ordered_attribute?(property)
       end
   end
 end

--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -280,8 +280,8 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     context "when the resource is saved" do
       context "when the property is unordered" do
         it "returns everything which references the given resource by the given property" do
-          parent = persister.save(resource: resource_class.new)
-          parent2 = persister.save(resource: resource_class.new)
+          parent = persister.save(resource: Valkyrie::Specs::SecondResource.new)
+          parent2 = persister.save(resource: Valkyrie::Specs::SecondResource.new)
           child = persister.save(resource: resource_class.new(a_member_of: [parent.id]))
           child2 = persister.save(resource: resource_class.new(a_member_of: [parent.id, parent2.id, parent.id]))
           persister.save(resource: resource_class.new)
@@ -291,7 +291,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
         end
 
         it "returns an empty array if there are none" do
-          parent = persister.save(resource: resource_class.new)
+          parent = persister.save(resource: Valkyrie::Specs::SecondResource.new)
 
           expect(query_service.find_inverse_references_by(resource: parent, property: :a_member_of).to_a).to eq []
         end
@@ -299,7 +299,7 @@ RSpec.shared_examples 'a Valkyrie query provider' do
 
       context "when the property is ordered" do
         it "returns everything which references the given resource by the given property" do
-          parent = persister.save(resource: resource_class.new)
+          parent = persister.save(resource: Valkyrie::Specs::SecondResource.new)
           child = persister.save(resource: resource_class.new(an_ordered_member_of: [parent.id]))
           child2 = persister.save(resource: resource_class.new(an_ordered_member_of: [parent.id, parent.id]))
           persister.save(resource: resource_class.new)
@@ -312,8 +312,8 @@ RSpec.shared_examples 'a Valkyrie query provider' do
 
     context "when id is passed instead of resource" do
       it "returns everything which references the given resource by the given property" do
-        parent = persister.save(resource: resource_class.new)
-        parent2 = persister.save(resource: resource_class.new)
+        parent = persister.save(resource: Valkyrie::Specs::SecondResource.new)
+        parent2 = persister.save(resource: Valkyrie::Specs::SecondResource.new)
         child = persister.save(resource: resource_class.new(a_member_of: [parent.id]))
         child2 = persister.save(resource: resource_class.new(a_member_of: [parent.id, parent2.id, parent.id]))
         persister.save(resource: resource_class.new)


### PR DESCRIPTION
Fixes #791

Removes the check on the parent resource to determine if the property is ordered.  This was a bug as the property is expected to be defined on the child.  The shared specs were adjusted to create classes where the property is ordered in one child class, unordered in a second child class, and the property does not exist in the parent.

Fedora was the only adapter with the bug in how it found resources through the inverse relationship. Fedora stores ordered and unordered using a different pattern, so the find_inverse_reference_by method was modified to find children using both patterns.

@escowles @tpendragon This is ready for review.