### PR TITLE
Use example.com instead of made-up URLs

### DIFF
--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -6,7 +6,7 @@ module Valkyrie::Persistence::Fedora
   #   Valkyrie::Persistence::Fedora::MetadataAdapter.new(
   #     connection: ::Ldp::Client.new("http://localhost:8988/rest"),
   #     base_path: "test_fed",
-  #     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title"))
+  #     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://example.com/title"))
   #   )
   class MetadataAdapter
     attr_reader :connection, :base_path, :schema, :fedora_version

--- a/lib/valkyrie/persistence/fedora/permissive_schema.rb
+++ b/lib/valkyrie/persistence/fedora/permissive_schema.rb
@@ -6,8 +6,8 @@ module Valkyrie::Persistence::Fedora
   #
   # @example Passing in a mapping
   #   schema = Valkyrie::Persistence::Fedora::PermissiveSchema.new(member_ids:
-  #     RDF::URI("http://mypredicates.com/member_ids"))
-  #   schema.predicate_for(resource: Resource.new, property: :member_ids) # => RDF::URI<"http://mypredicates.com/member_ids">
+  #     RDF::URI("http://example.com/member_ids"))
+  #   schema.predicate_for(resource: Resource.new, property: :member_ids) # => RDF::URI<"http://example.com/member_ids">
   #   schema.predicate_for(resource: Resource.new, property: :unknown) # => RDF::URI<"http://example.com/predicate/unknown">
   class PermissiveSchema
     URI_PREFIX = 'http://example.com/predicate/'

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -84,14 +84,14 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
 
   it "can support deep nesting of resources" do
     pending "No support for deep nesting." if flags.include?(:no_deep_nesting)
-    book = resource_class.new(title: "Sub-nested", author: [Valkyrie::ID.new("test"), RDF::Literal.new("Test", language: :fr), RDF::URI("http://test.com")])
+    book = resource_class.new(title: "Sub-nested", author: [Valkyrie::ID.new("test"), RDF::Literal.new("Test", language: :fr), RDF::URI("http://example.com")])
     book2 = resource_class.new(title: "Nested", nested_resource: book)
     book3 = persister.save(resource: resource_class.new(nested_resource: book2))
 
     reloaded = query_service.find_by(id: book3.id)
     expect(reloaded.nested_resource.first.title).to eq ["Nested"]
     expect(reloaded.nested_resource.first.nested_resource.first.title).to eq ["Sub-nested"]
-    expect(reloaded.nested_resource.first.nested_resource.first.author).to contain_exactly Valkyrie::ID.new("test"), RDF::Literal.new("Test", language: :fr), RDF::URI("http://test.com")
+    expect(reloaded.nested_resource.first.nested_resource.first.author).to contain_exactly Valkyrie::ID.new("test"), RDF::Literal.new("Test", language: :fr), RDF::URI("http://example.com")
   end
 
   it "stores created_at/updated_at" do

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Valkyrie::Persistence::Fedora::Persister, :wipe_fedora do
         Valkyrie::Persistence::Fedora::MetadataAdapter.new(
           fedora_adapter_config(
             base_path: "test_fed",
-            schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://bad.com/title")),
+            schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(title: RDF::URI("http://example.com/title")),
             fedora_version: version
           )
         )


### PR DESCRIPTION
We should use the existing example.com/example.org URLs for tests, not made-up URLs that might be registered.