### PR TITLE
Randomizing order of spec execution

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,8 @@ ROOT_PATH = Pathname.new(Dir.pwd)
 Dir[Pathname.new("./").join("spec", "support", "**", "*.rb")].sort.each { |file| require_relative file.gsub(/^spec\//, "") }
 
 WebMock.disable_net_connect!(allow_localhost: true)
+
+RSpec.configure do |config|
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
Prior to this commit, it appeared that the specs ran in a sequential
order. Assuming they are running in the same order during each test,
this could mean that we have unknown temporal dependencies in our code.

Could we switch Valkyrie's specs to run in random order, thus helping
tease out if there exist temporal dependencies in our code.

_In running them randomly it appears to preserve meaningful
documentation format._

Closes #797