### PR TITLE
Adding ability to suppress valkyrie logging

### DIFF
--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -14,6 +14,7 @@ require 'logger'
 require 'rdf/vocab'
 
 module Valkyrie
+  require 'valkyrie/logging'
   require 'valkyrie/id'
   require 'valkyrie/change_set'
   require 'valkyrie/value_mapper'
@@ -61,12 +62,16 @@ module Valkyrie
     end
   end
 
+  # @return [Valkyrie::Logging]
   def logger
-    @logger ||= Logger.new(STDOUT)
+    @logger ||= Valkyrie::Logging.new(logger: Logger.new(STDOUT))
   end
 
+  # Wraps the given logger in an instance of Valkyrie::Logging
+  #
+  # @param logger [Logger]
   def logger=(logger)
-    @logger = logger
+    @logger = Valkyrie::Logging.new(logger: logger)
   end
 
   class Config < OpenStruct

--- a/lib/valkyrie/logging.rb
+++ b/lib/valkyrie/logging.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+module Valkyrie
+  # A wrapper class for Valkyrie logging. This class attempts to provide
+  # tooling that helps improve the communication through-out the stack.
+  #
+  # In gem development there are several considerations regarding logging.
+  #
+  # 1) The development on the gem directly, in particular specs
+  # 2) The downstream development that leverages the gem, both when specs are
+  #    running and when running the downstream processes in a development
+  #    environment.
+  # 3) The downstream behaviors that are called in production environments.
+  #
+  # In each of these cases, different considerations regarding logging may be
+  # relevant.
+  #
+  # In the below example,
+  #
+  # @example
+  #   Valkyrie.logger.suppress_logging_for_contexts!("A Named Context") do
+  #     # The following will NOT be logged
+  #     Valkyrie.logger.warn('Hello', logging_context: "A Named Context")
+  #
+  #     # The following will be logged
+  #     Valkyrie.logger.warn('Hello')
+  #   end
+  #   # The following will be logged
+  #   Valkyrie.logger.warn('Hello', logging_context: "A Named Context")
+
+  class Logging < SimpleDelegator
+    # @param logger [Logger] the logger to which we'll delegate messages
+    def initialize(logger:)
+      @suppressions = {}
+      super(logger)
+    end
+
+    def warn(*args, logging_context: false, &block)
+      super(*args, *block) unless @suppressions.key?(logging_context)
+    end
+
+    def error(*args, logging_context: false, &block)
+      super(*args, *block) unless @suppressions.key?(logging_context)
+    end
+
+    def info(*args, logging_context: false, &block)
+      super(*args, *block) unless @suppressions.key?(logging_context)
+    end
+
+    def debug(*args, logging_context: false, &block)
+      super(*args, *block) unless @suppressions.key?(logging_context)
+    end
+
+    def fatal(*args, logging_context: false, &block)
+      super(*args, *block) unless @suppressions.key?(logging_context)
+    end
+
+    def suppress_logging_for_contexts!(*logging_contexts)
+      Array(logging_contexts).each do |logging_context|
+        @suppressions[logging_context] = true
+      end
+      return unless block_given?
+      yield
+      clear_suppressions!(*logging_contexts)
+    end
+
+    def clear_suppressions!(*logging_contexts)
+      Array(logging_contexts).each do |logging_context|
+        @suppressions.delete(logging_context)
+      end
+    end
+  end
+end

--- a/lib/valkyrie/persistence/fedora/persister.rb
+++ b/lib/valkyrie/persistence/fedora/persister.rb
@@ -64,11 +64,13 @@ module Valkyrie::Persistence::Fedora
     # (see Valkyrie::Persistence::Memory::Persister#wipe!)
     # Deletes Fedora repository resource *and* the tombstone resources which remain
     # @see https://wiki.duraspace.org/display/FEDORA4x/RESTful+HTTP+API#RESTfulHTTPAPI-RedDELETEDeletearesource
+    # @see Valkyrie::Logging for details concerning log suppression.
     def wipe!
       connection.delete(base_path)
       connection.delete("#{base_path}/fcr:tombstone")
     rescue => error
-      Valkyrie.logger.debug("Failed to wipe Fedora for some reason: #{error}") unless error.is_a?(::Ldp::NotFound)
+      return unless error.is_a?(::Ldp::NotFound)
+      Valkyrie.logger.debug("Failed to wipe Fedora for some reason: #{error}", logging_context: "Valkyrie::Persistence::Fedora::Persister#wipe")
     end
 
     # Creates the root LDP Container for the connection with Fedora

--- a/lib/valkyrie/persistence/solr/repository.rb
+++ b/lib/valkyrie/persistence/solr/repository.rb
@@ -62,8 +62,9 @@ module Valkyrie::Persistence::Solr
     # Given a new Valkyrie Resource, generate a random UUID and assign it to the Resource
     # @param [Valkyrie::Resource] resource
     # @param [String] the UUID for the new resource
+    # @see Valkyrie::Logging for details concerning log suppression.
     def generate_id(resource)
-      Valkyrie.logger.warn "The Solr adapter is not meant to persist new resources, but is now generating an ID."
+      Valkyrie.logger.warn("The Solr adapter is not meant to persist new resources, but is now generating an ID.", logging_context: "Valkyrie::Persistence::Solr::Repository#generate_id")
       resource.id = SecureRandom.uuid
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,6 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+# See Valkyrie::Logging for specific details
+Valkyrie.logger.suppress_logging_for_contexts!("Valkyrie::Persistence::Solr::Repository#generate_id")

--- a/spec/valkyrie/logging_spec.rb
+++ b/spec/valkyrie/logging_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Valkyrie::Logging do
+  let(:logging_delegator) { described_class.new(logger: logger) }
+  let(:logger) { instance_double("Logger") }
+  describe '#warn' do
+    let(:logger) { instance_double("Logger", warn: true) }
+    describe 'with suppressed logging' do
+      it 'will not log a suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.warn('Hello', logging_context: :salutations)
+        end
+        expect(logger).not_to have_received(:warn).with('Hello')
+      end
+      it 'will log a non-suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.warn('Hello', logging_context: :something_elses)
+        end
+        expect(logger).to have_received(:warn).with('Hello')
+      end
+    end
+    it 'preserves the interface of the underlying logger' do
+      logging_delegator.warn('You have one interface!')
+      expect(logger).to have_received(:warn).with('You have one interface!')
+    end
+  end
+  describe '#info' do
+    let(:logger) { instance_double("Logger", info: true) }
+    describe 'with suppressed logging' do
+      it 'will not log a suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.info('Hello', logging_context: :salutations)
+        end
+        expect(logger).not_to have_received(:info).with('Hello')
+      end
+      it 'will log a non-suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.info('Hello', logging_context: :something_elses)
+        end
+        expect(logger).to have_received(:info).with('Hello')
+      end
+    end
+    it 'preserves the interface of the underlying logger' do
+      logging_delegator.info('You have one interface!')
+      expect(logger).to have_received(:info).with('You have one interface!')
+    end
+  end
+  describe '#error' do
+    let(:logger) { instance_double("Logger", error: true) }
+    describe 'with suppressed logging' do
+      it 'will not log a suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.error('Hello', logging_context: :salutations)
+        end
+        expect(logger).not_to have_received(:error).with('Hello')
+      end
+      it 'will log a non-suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.error('Hello', logging_context: :something_elses)
+        end
+        expect(logger).to have_received(:error).with('Hello')
+      end
+    end
+    it 'preserves the interface of the underlying logger' do
+      logging_delegator.error('You have one interface!')
+      expect(logger).to have_received(:error).with('You have one interface!')
+    end
+  end
+  describe '#fatal' do
+    let(:logger) { instance_double("Logger", fatal: true) }
+    describe 'with suppressed logging' do
+      it 'will not log a suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.fatal('Hello', logging_context: :salutations)
+        end
+        expect(logger).not_to have_received(:fatal).with('Hello')
+      end
+      it 'will log a non-suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.fatal('Hello', logging_context: :something_elses)
+        end
+        expect(logger).to have_received(:fatal).with('Hello')
+      end
+    end
+    it 'preserves the interface of the underlying logger' do
+      logging_delegator.fatal('You have one interface!')
+      expect(logger).to have_received(:fatal).with('You have one interface!')
+    end
+  end
+  describe '#debug' do
+    let(:logger) { instance_double("Logger", debug: true) }
+    describe 'with suppressed logging' do
+      it 'will not log a suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.debug('Hello', logging_context: :salutations)
+        end
+        expect(logger).not_to have_received(:debug).with('Hello')
+      end
+      it 'will log a non-suppressed logging_context' do
+        logging_delegator.suppress_logging_for_contexts!(:salutations) do
+          logging_delegator.debug('Hello', logging_context: :something_elses)
+        end
+        expect(logger).to have_received(:debug).with('Hello')
+      end
+    end
+    it 'preserves the interface of the underlying logger' do
+      logging_delegator.debug('You have one interface!')
+      expect(logger).to have_received(:debug).with('You have one interface!')
+    end
+  end
+
+  it 'is a SimpleDelegator wrapper for the given logger' do
+    expect(logging_delegator).to be_a(SimpleDelegator)
+  end
+end


### PR DESCRIPTION
In gem development there are several considerations regarding logging.

1) The development on the gem directly, in particular specs
2) The downstream development that leverages the gem, both when specs
  are running and when running the downstream processes in a development
  environment.
3) The downstream behaviors that are called in production environments.

This patch provides the ability for developers to suppress logs.

Closes #796