### PR TITLE
Fixing logging error

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister.rb
+++ b/lib/valkyrie/persistence/fedora/persister.rb
@@ -69,8 +69,7 @@ module Valkyrie::Persistence::Fedora
       connection.delete(base_path)
       connection.delete("#{base_path}/fcr:tombstone")
     rescue => error
-      return unless error.is_a?(::Ldp::NotFound)
-      Valkyrie.logger.debug("Failed to wipe Fedora for some reason: #{error}", logging_context: "Valkyrie::Persistence::Fedora::Persister#wipe")
+      Valkyrie.logger.debug("Failed to wipe Fedora for some reason: #{error}", logging_context: "Valkyrie::Persistence::Fedora::Persister#wipe") unless error.is_a?(::Ldp::NotFound)
     end
 
     # Creates the root LDP Container for the connection with Fedora


### PR DESCRIPTION
I introduced an error in logic in commit c670eaa4eb252e048f97335e63b983731f35cbc7

Prior to c670eaa4eb252e048f97335e63b983731f35cbc7 was, in effect, the
following:

```ruby
Valkyrie.logger.error unless error.is_a?(::Ldp::NotFound)
```

However, with c670eaa4eb252e048f97335e63b983731f35cbc7 it logically
became:

```ruby
return unless error.is_a?(::Ldp::NotFound)
Valkyrie.logger.error
```

The end result is that there exists a lot more logging that is in error.