### PR TITLE
Promote logic to method

### DIFF
--- a/lib/valkyrie/persistence/composite_persister.rb
+++ b/lib/valkyrie/persistence/composite_persister.rb
@@ -30,7 +30,7 @@ module Valkyrie::Persistence
       cached_resource = first.save(resource: resource)
       # Don't pass opt lock tokens to other persisters
       internal_resource = cached_resource.dup
-      internal_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", []) if internal_resource.optimistic_locking_enabled?
+      internal_resource.clear_optimistic_lock_token!
       rest.inject(internal_resource) { |m, persister| persister.save(resource: m) }
       # return the one with the desired opt lock token
       cached_resource

--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -113,6 +113,10 @@ module Valkyrie
       self.class.optimistic_locking_enabled?
     end
 
+    def clear_optimistic_lock_token!
+      send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", []) if optimistic_locking_enabled?
+    end
+
     def attributes
       Hash[self.class.attribute_names.map { |x| [x, nil] }].merge(super).freeze
     end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -360,7 +360,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
           resource = MyLockingResource.new(title: ["My Locked Resource"])
           initial_resource = persister.save(resource: resource)
           initial_token = initial_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].first
-          initial_resource.send("#{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK}=", [])
+          initial_resource.clear_optimistic_lock_token!
           updated_resource = persister.save(resource: initial_resource)
           expect(initial_token.serialize)
             .not_to eq(updated_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].first.serialize)

--- a/spec/valkyrie/resource_spec.rb
+++ b/spec/valkyrie/resource_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe Valkyrie::Resource do
           expect(resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK][0]).to be_a Valkyrie::Persistence::OptimisticLockToken
         end
       end
+      describe ".clear_optimistic_lock_token!" do
+        it "sets the #{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK} attribute to an empty Array" do
+          lock_token = Valkyrie::Persistence::OptimisticLockToken.deserialize("lock_token:adapter_id:a_tok:en")
+          resource = MyLockingResource.new(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK => lock_token)
+          expect do
+            resource.clear_optimistic_lock_token!
+          end.to change { resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK) }.from([lock_token]).to([])
+        end
+      end
     end
 
     context "when it is not enabled" do
@@ -190,6 +199,14 @@ RSpec.describe Valkyrie::Resource do
         expect(MyNonlockingResource.new).not_to respond_to(:optimistic_lock_token)
         expect(MyNonlockingResource.new.optimistic_locking_enabled?).to be false
         expect(MyNonlockingResource.optimistic_locking_enabled?).to be false
+      end
+
+      describe ".clear_optimistic_lock_token!" do
+        it "makes no attempt to set the #{Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK} attribute" do
+          resource = MyNonlockingResource.new
+          resource.clear_optimistic_lock_token!
+          expect { resource.send(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK) }.to raise_error(NoMethodError)
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, the logic for clearing the optimistic lock resided
outside the resource that code be locked. In addition, it used a `#send`
message that had intimate knowledge about attribute implementation.

This commit wraps that logic into a single method.