### PR TITLE
Adding parity in schema.key lookup

### DIFF
--- a/lib/valkyrie/resource.rb
+++ b/lib/valkyrie/resource.rb
@@ -187,7 +187,7 @@ module Valkyrie
 
     # Returns if an attribute is set as ordered.
     def ordered_attribute?(key)
-      self.class.schema.key(key).type.meta.try(:[], :ordered)
+      self.class.schema.key(key.to_sym).type.meta.try(:[], :ordered)
     end
 
     class ReservedAttributeError < StandardError; end


### PR DESCRIPTION
In a sibling method, we use `self.class.schema.key(key.to_sym)`. Prior
to this commit, the changed method used `self.class.schema.key(key)`.
With the change, I'm adding symmetry to the `schema.key` lookup to align
expectations.