### PR TITLE
Suppressing warning in more generalized case

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,14 @@ WebMock.disable_net_connect!(allow_localhost: true)
 RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
-end
 
-# See Valkyrie::Logging for specific details
-Valkyrie.logger.suppress_logging_for_contexts!("Valkyrie::Persistence::Solr::Repository#generate_id")
+  config.before do
+    # See Valkyrie::Logging for specific details
+    Valkyrie.logger.suppress_logging_for_contexts!("Valkyrie::Persistence::Solr::Repository#generate_id")
+  end
+
+  config.after do
+    # See Valkyrie::Logging for specific details
+    Valkyrie.logger.clear_suppressions!
+  end
+end


### PR DESCRIPTION
Prior to this commit, when I ran `rspec --seed 2053`, I would see logged
warnings. My suspicion is that that logger suppressions were getting
cleared.

After this commit, the suppression is redeclared as part of each run.