### PR TITLE
Tidying up spec documentation output

### DIFF
--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe Valkyrie::Types do
     end
   end
 
-  describe Valkyrie::Types::OptimisticLockToken do
+  describe "Valkyrie::Types::OptimisticLockToken" do
     it "casts from a string" do
       serialized_token = Valkyrie::Persistence::OptimisticLockToken.new(adapter_id: "adapter_id", token: Valkyrie::ID.new("token")).serialize
 
-      expect(described_class[serialized_token]).to be_a Valkyrie::Persistence::OptimisticLockToken
+      expect(Valkyrie::Types::OptimisticLockToken[serialized_token]).to be_a Valkyrie::Persistence::OptimisticLockToken
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the documentation read as follows:

```console
Valkyrie::Types
  #<Dry::Types[Constructor<Nominal<Valkyrie::Persistence::OptimisticLockToken> fn=lib/valkyrie/types.rb:57>]>
    casts from a string
```

With the change, we now get:

```console
Valkyrie::Types
  Valkyrie::Types::OptimisticLockToken
    casts from a string
```

I find this more legible and less surprising when reading the specs.
With the prior format, I'm left wondering "is there a stray puts call?"
I see the prior output as something "programmatic and as not clear as
documentation."

This attempts to tidy that up. However, I see this as something up for
discussion.