### PR TITLE
Tidying up documentation

### DIFF
--- a/lib/valkyrie/persistence/memory/query_service.rb
+++ b/lib/valkyrie/persistence/memory/query_service.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module Valkyrie::Persistence::Memory
+  # Query Service for the memory metadata adapter.
+  # @see Valkyrie::Persistence::Memory
+  # @note Documentation for Query Services in general is maintained here.
   class QueryService
-    # Query Service for the memory metadata adapter.
-    # @see Valkyrie::Persistence::Memory
-    # @note Documentation for Query Services in general is maintained here.
     attr_reader :adapter, :query_handlers
     delegate :cache, to: :adapter
 


### PR DESCRIPTION
Prior to this commit, the documentation for the class was disassociated
with the class. After this commit, the documentation (as rendered) will
be associated with the class.