### PR TITLE
Use `::` prefixed names for `JSON::LD` references

### DIFF
--- a/lib/valkyrie/rdf_patches.rb
+++ b/lib/valkyrie/rdf_patches.rb
@@ -6,12 +6,12 @@
 module RDF
   class Literal
     def as_json(*_args)
-      JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
+      ::JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
     end
   end
   class URI
     def as_json(*_args)
-      JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
+      ::JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
     end
   end
 end


### PR DESCRIPTION
`RDF::JSON` exists in some contexts, e.g. after `require `linkeddata`. When it
does, this name fails to resolve. Using the anchor `::` ensures we look for
`JSON::LD` in the top level namespace.

Fixes #772 