### PR TITLE
Place new ID equality behind a config option.

### DIFF
--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -88,6 +88,19 @@ module Valkyrie
     end
 
     # @api public
+    # Configure id_string_equality to be true in order to make Valkyrie::ID
+    # equal to the string value they contain. This will be the default behavior
+    # in v3.0.0.
+    #
+    # @return [Boolean] Whether `Valkyrie::ID` should be equal to their string counterpart.
+    def id_string_equality
+      super
+    end
+
+    # @!attribute [w] id_string_equality=
+    #   The setter for #id_string_equality; see it's implementation
+
+    # @api public
     #
     # The returned anonymous method (e.g. responds to #call) has a signature of
     # an unamed parameter that is a string. Calling the anonymous method should

--- a/lib/valkyrie/id.rb
+++ b/lib/valkyrie/id.rb
@@ -17,12 +17,26 @@ module Valkyrie
     delegate :hash, to: :state
 
     def eql?(other)
-      (other.class == self.class && other.state == state) ||
-        (other.to_s == to_s)
+      return (default_equality(other) || string_equality(other)) if Valkyrie.config.id_string_equality == true
+      default_equality(other)
     end
     alias == eql?
 
     protected
+
+      def default_equality(other)
+        output = (other.class == self.class && other.state == state)
+        return output if output == true
+        if output == false && string_equality(other) && Valkyrie.config.id_string_equality.nil?
+          warn "[DEPRECATION] Valkyrie::IDs will always be equal to their string counterparts in 3.0.0. " \
+            "To silence this message, please either compare IDs or set Valkyrie.config.id_string_equality = true."
+        end
+        false
+      end
+
+      def string_equality(other)
+        other.to_s == to_s
+      end
 
       def state
         [@id]

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -35,13 +35,28 @@ RSpec.describe Valkyrie::Types do
     end
 
     context 'when a string is passed in' do
+      let(:message) do
+        /\[DEPRECATION\] Valkyrie::IDs will always be equal to their string counterparts in 3.0.0. To silence this message, please either compare IDs or set Valkyrie.config.id_string_equality = true./
+      end
       let(:thumbnail_id) { '123' }
 
       it 'casts to a string' do
         expect(resource.thumbnail_id).to eq Valkyrie::ID.new('123')
       end
 
-      it 'equals the equivalent string if ID matches string' do
+      it 'does not equal the equivalent string if ID matches string' do
+      end
+
+      it "doesn't echo a deprecated message if configured" do
+        Valkyrie.config.id_string_equality = false
+        expect do
+          expect(resource.thumbnail_id).not_to eq '123'
+        end.not_to output(message).to_stderr
+      end
+
+      it 'equals the equivalent string if Valkyrie is configured' do
+        allow(Valkyrie.config).to receive(:id_string_equality).and_return(true)
+
         expect(resource.thumbnail_id).to eq '123'
       end
     end


### PR DESCRIPTION
This allows us to release without a major version, and we can deprecate
it later.