### PR TITLE
Lock Faraday to < 1.0.

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
   spec.add_dependency 'rdf-vocab'
   spec.add_dependency 'disposable', '~> 0.4.5'
+  spec.add_dependency 'faraday', '~> 0.17'
 
   spec.add_development_dependency "bundler", "> 1.16.0", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
RSolr can't handle Faraday 1.0 yet. We should be able to loosen this
later.