### PR TITLE
Don't actually set config for ID equality.

### DIFF
--- a/lib/valkyrie/id.rb
+++ b/lib/valkyrie/id.rb
@@ -28,10 +28,8 @@ module Valkyrie
         output = (other.class == self.class && other.state == state)
         return output if output == true
         if output == false && string_equality(other) && Valkyrie.config.id_string_equality.nil?
-          # :nocov:
           warn "[DEPRECATION] Valkyrie::IDs will always be equal to their string counterparts in 3.0.0. " \
             "To silence this message, please either compare IDs or set Valkyrie.config.id_string_equality = true."
-          # :nocov:
         end
         false
       end

--- a/spec/valkyrie/types_spec.rb
+++ b/spec/valkyrie/types_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Valkyrie::Types do
       end
 
       it "doesn't echo a deprecated message if configured" do
-        Valkyrie.config.id_string_equality = false
+        allow(Valkyrie.config).to receive(:id_string_equality).and_return(false)
         expect do
           expect(resource.thumbnail_id).not_to eq '123'
         end.not_to output(message).to_stderr


### PR DESCRIPTION
This makes the coverage always work. Thanks to @dgcliff