### PR TITLE
allow open-ended rake support

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '< 1.0'
 
   spec.add_development_dependency "bundler", "> 1.16.0", "< 3"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 10"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
older versions of rake have security vulnerabilities. since `rake` is
particularly stable, and it's just a development dependency, it seems safe to
leave it open ended.

this probably doesn't need an immediate release.