### PR TITLE
Making sure Valkyrie uses DateTime consistently.

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
@@ -318,7 +318,7 @@ module Valkyrie::Persistence::Fedora
           # Casts the value of the RDF literal into an Applicator for DateTime values
           # @return [Applicator]
           def result
-            value.statement.object = ::DateTime.iso8601(value.statement.object.to_s).utc
+            value.statement.object = ::DateTime.iso8601(value.statement.object.to_s).new_offset(0)
             calling_mapper.for(Property.new(statement: value.statement, scope: value.scope, adapter: value.adapter)).result
           end
         end
@@ -394,7 +394,7 @@ module Valkyrie::Persistence::Fedora
           # Casts the value of the RDF literal into an Applicator for DateTime values
           # @return [Applicator]
           def result
-            value.statement.object = Time.parse(value.statement.object.to_s).utc
+            value.statement.object = DateTime.parse(value.statement.object.to_s).new_offset(0)
             calling_mapper.for(Property.new(statement: value.statement, scope: value.scope, adapter: value.adapter)).result
           end
         end

--- a/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
@@ -556,11 +556,7 @@ module Valkyrie::Persistence::Fedora
           # @param [Object] values
           # @return [Array<Object>]
           def cast_array(values)
-            if values.is_a?(Time)
-              [values]
-            else
               Array(values)
-            end
           end
 
           # Retrieve a list of blacklisted URIs for predicates

--- a/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
@@ -556,7 +556,7 @@ module Valkyrie::Persistence::Fedora
           # @param [Object] values
           # @return [Array<Object>]
           def cast_array(values)
-              Array(values)
+            Array(values)
           end
 
           # Retrieve a list of blacklisted URIs for predicates

--- a/lib/valkyrie/persistence/memory/persister.rb
+++ b/lib/valkyrie/persistence/memory/persister.rb
@@ -77,8 +77,8 @@ module Valkyrie::Persistence::Memory
       end
 
       def normalize_date_value(value)
-        return value.utc if value.is_a?(DateTime)
-        return value.to_datetime.utc if value.is_a?(Time)
+        return value.new_offset(0) if value.is_a?(DateTime)
+        return value.to_datetime.new_offset(0) if value.is_a?(Time)
         value
       end
 

--- a/lib/valkyrie/persistence/shared/json_value_mapper.rb
+++ b/lib/valkyrie/persistence/shared/json_value_mapper.rb
@@ -152,7 +152,7 @@ module Valkyrie::Persistence::Shared
       # Generates a Time object in the UTC from the datestamp string value
       # @return [Time]
       def result
-        DateTime.iso8601(value).utc
+        DateTime.iso8601(value).new_offset(0)
       end
     end
   end

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -378,8 +378,8 @@ module Valkyrie::Persistence::Solr
           # @param [Object] value
           # @return [Time]
           def to_datetime(value)
-            return value.utc if value.is_a?(DateTime)
-            return value.to_datetime.utc if value.respond_to?(:to_datetime)
+            return value.new_offset(0) if value.is_a?(DateTime)
+            return value.to_datetime.new_offset(0) if value.respond_to?(:to_datetime)
           end
       end
 

--- a/lib/valkyrie/persistence/solr/orm_converter.rb
+++ b/lib/valkyrie/persistence/solr/orm_converter.rb
@@ -48,7 +48,7 @@ module Valkyrie::Persistence::Solr
     # Construct a Time object from the datestamp for the resource creation date indexed in Solr
     # @return [Time]
     def created_at
-      DateTime.parse(solr_document.fetch("created_at_dtsi").to_s).utc
+      DateTime.parse(solr_document.fetch("created_at_dtsi").to_s).new_offset(0)
     end
 
     # Construct a Time object from the datestamp for the date of the last resource update indexed in Solr
@@ -445,7 +445,7 @@ module Valkyrie::Persistence::Solr
       # @return [Boolean]
       def self.handles?(value)
         return false unless value.to_s.start_with?("datetime-")
-        DateTime.iso8601(value.sub(/^datetime-/, '')).utc
+        DateTime.iso8601(value.sub(/^datetime-/, '')).new_offset(0)
       rescue
         false
       end
@@ -453,7 +453,7 @@ module Valkyrie::Persistence::Solr
       # Parses and casts the Solr field value into a UTC DateTime value
       # @return [Time]
       def result
-        DateTime.parse(value.sub(/^datetime-/, '')).utc
+        DateTime.parse(value.sub(/^datetime-/, '')).new_offset(0)
       end
     end
   end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -194,9 +194,9 @@ RSpec.shared_examples 'a Valkyrie::Persister' do |*flags|
     reloaded = query_service.find_by(id: book.id)
 
     expect(reloaded.title.first.to_i).to eq(time1.to_i)
-    expect(reloaded.title.first.zone).to eq('UTC')
+    expect(reloaded.title.first.zone).to eq('+00:00')
     expect(reloaded.author.first.to_i).to eq(time2.to_i)
-    expect(reloaded.author.first.zone).to eq('UTC')
+    expect(reloaded.author.first.zone).to eq('+00:00')
     expect(reloaded.other_author.first).to eq "2019-01"
   end
 

--- a/spec/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/valkyrie/persistence/solr/persister_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
     let(:resource_class) { CustomResource }
 
     it "Returns a string when DateTime conversion fails" do
-      time1 = DateTime.current.utc
+      time1 = DateTime.current.new_offset(0)
       time2 = Time.current.utc
       allow(DateTime).to receive(:iso8601).and_raise StandardError.new("bogus exception")
       book = persister.save(resource: resource_class.new(title: [time1], author: [time2]))


### PR DESCRIPTION
See #830. Valkyrie normalizes DateTime values to UTC to ensure consistency. This commit changes the method used from `.utc` to `.new_offset(0)`. The former returns a Time rather than a DateTime, which causes the type checking in the strict DateTime type to fail. The latter does the same thing, but returns a DateTime. The PR also rewrites tests to expect the DateTime format for the UTC zone, '+00:00', rather than 'UTC'.