### PR TITLE
loosen `rdf` dependency to allow 3.1+

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'draper'
   spec.add_dependency 'activemodel'
   spec.add_dependency 'dry-types', '~> 1.0'
-  spec.add_dependency 'rdf', '~> 3.0.10'
+  spec.add_dependency 'rdf', '~> 3.0', '>= 3.0.10'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'railties' # To use generators and engines
   spec.add_dependency 'reform'


### PR DESCRIPTION
RDF.rb 3.0.x doesn't support Ruby 3. there is (hopefully) no need to lock the
dependency so tightly, since the RDF gems carefully follow SemVer.