### PR TITLE
Update resource.rb

### DIFF
--- a/lib/valkyrie/specs/shared_specs/resource.rb
+++ b/lib/valkyrie/specs/shared_specs/resource.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'a Valkyrie::Resource' do
       end
     end
 
-    describe "#fields" do
+    describe ".fields" do
       it "returns a set of fields" do
         expect(meta_klass).to respond_to(:fields).with(0).arguments
         expect(meta_klass.fields).to include(:id)


### PR DESCRIPTION
Changes a spec doc string to indicate a class method instead of instance method.