### PR TITLE
Adds test for branch name to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,16 @@ jobs:
       FEDORA_6_PORT: 8080
     steps:
       - checkout
+
+      - run:
+          name: Check for 'master' branch
+          command: |
+              git fetch --all --quiet --prune --prune-tags
+              if [[ -n "$(git branch --all --list master */master)" ]]; then
+                  echo "A branch named 'master' was found. Please remove it."
+                  echo "$(git branch --all --list master */master)"
+              fi
+              [[ -z "$(git branch --all --list master */master)" ]]
       - run:
           name: Wait for solr
           command: dockerize -wait tcp://localhost:8994 -timeout 1m


### PR DESCRIPTION
This adds a test in CircleCI that will fail if there is a branch called "master" on the remote.  This is intended to help report on errors if any contributor mistakenly pushes an old branch from a local fork.