### PR TITLE
Initial run at shared write-only persisters.

### DIFF
--- a/lib/valkyrie/persistence/solr/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/solr/metadata_adapter.rb
@@ -27,18 +27,23 @@ module Valkyrie::Persistence::Solr
   #     )
   #   )
   class MetadataAdapter
-    attr_reader :connection, :resource_indexer
+    attr_reader :connection, :resource_indexer, :write_only
     # @param connection [RSolr::Client] The RSolr connection to index to.
     # @param resource_indexer [Class, #to_solr] An indexer which is able to
     #   receive a `resource` argument and then has an instance method `#to_solr`
-    def initialize(connection:, resource_indexer: NullIndexer)
+    def initialize(connection:, resource_indexer: NullIndexer, write_only: false)
       @connection = connection
       @resource_indexer = resource_indexer
+      @write_only = write_only
     end
 
     # @return [Valkyrie::Persistence::Solr::Persister] The solr persister.
     def persister
       Valkyrie::Persistence::Solr::Persister.new(adapter: self)
+    end
+
+    def write_only?
+      write_only
     end
 
     # @return [Valkyrie::Persistence::Solr::QueryService] The solr query

--- a/lib/valkyrie/persistence/solr/persister.rb
+++ b/lib/valkyrie/persistence/solr/persister.rb
@@ -15,6 +15,7 @@ module Valkyrie::Persistence::Solr
     end
 
     # (see Valkyrie::Persistence::Memory::Persister#save)
+    # @return [Boolean] If write_only, whether saving succeeded.
     def save(resource:)
       if write_only?
         repository([resource]).persist
@@ -24,6 +25,7 @@ module Valkyrie::Persistence::Solr
     end
 
     # (see Valkyrie::Persistence::Memory::Persister#save_all)
+    # @return [Boolean] If write_only, whether saving succeeded.
     def save_all(resources:)
       repository(resources).persist
     end

--- a/lib/valkyrie/persistence/solr/persister.rb
+++ b/lib/valkyrie/persistence/solr/persister.rb
@@ -6,7 +6,7 @@ module Valkyrie::Persistence::Solr
   # Most methods are delegated to {Valkyrie::Persistence::Solr::Repository}
   class Persister
     attr_reader :adapter
-    delegate :connection, :resource_factory, to: :adapter
+    delegate :connection, :resource_factory, :write_only?, to: :adapter
 
     # @param adapter [Valkyrie::Persistence::Solr::MetadataAdapter] The adapter with the
     #   configured solr connection.
@@ -16,7 +16,11 @@ module Valkyrie::Persistence::Solr
 
     # (see Valkyrie::Persistence::Memory::Persister#save)
     def save(resource:)
-      repository([resource]).persist.first
+      if write_only?
+        repository([resource]).persist
+      else
+        repository([resource]).persist.first
+      end
     end
 
     # (see Valkyrie::Persistence::Memory::Persister#save_all)
@@ -39,7 +43,7 @@ module Valkyrie::Persistence::Solr
     # @param [Array<Valkyrie::Resource>] resources
     # @return [Valkyrie::Persistence::Solr::Repository]
     def repository(resources)
-      Valkyrie::Persistence::Solr::Repository.new(resources: resources, connection: connection, resource_factory: resource_factory)
+      Valkyrie::Persistence::Solr::Repository.new(resources: resources, persister: self)
     end
   end
 end

--- a/lib/valkyrie/specs/shared_specs.rb
+++ b/lib/valkyrie/specs/shared_specs.rb
@@ -13,3 +13,5 @@ require 'valkyrie/specs/shared_specs/change_set_persister.rb'
 require 'valkyrie/specs/shared_specs/file.rb'
 require 'valkyrie/specs/shared_specs/change_set.rb'
 require 'valkyrie/specs/shared_specs/solr_indexer.rb'
+# Write-only tests.
+require 'valkyrie/specs/shared_specs/write_only/metadata_adapter.rb'

--- a/lib/valkyrie/specs/shared_specs/write_only/metadata_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/write_only/metadata_adapter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'a write-only Valkyrie::MetadataAdapter' do |passed_adapter|
+  before do
+    raise 'adapter must be set with `let(:adapter)`' unless
+      defined? adapter
+  end
+  subject { passed_adapter || adapter }
+  let(:persister) { adapter.persister }
+  it { is_expected.to respond_to(:persister).with(0).arguments }
+  it { is_expected.to respond_to(:id).with(0).arguments }
+
+  describe "#id" do
+    it "is a valid string representation of an MD5 hash" do
+      expect(adapter.id).to be_a Valkyrie::ID
+      expect(adapter.id.to_s.length).to eq 32
+      expect(adapter.id.to_s).to match(/^[a-f,0-9]+$/)
+    end
+  end
+
+  describe "#write_only?" do
+    it "returns true" do
+      expect(adapter).to be_write_only
+    end
+  end
+
+  describe "persister" do
+    before do
+      class WriteOnlyCustomResource < Valkyrie::Resource
+        include Valkyrie::Resource::AccessControls
+        attribute :title
+        attribute :author
+        attribute :other_author
+        attribute :member_ids
+        attribute :nested_resource
+        attribute :single_value, Valkyrie::Types::String.optional
+        attribute :ordered_authors, Valkyrie::Types::Array.of(Valkyrie::Types::Anything).meta(ordered: true)
+        attribute :ordered_nested, Valkyrie::Types::Array.of(WriteOnlyCustomResource).meta(ordered: true)
+      end
+    end
+    after do
+      Object.send(:remove_const, :WriteOnlyCustomResource)
+    end
+
+    subject { persister }
+    let(:resource_class) { WriteOnlyCustomResource }
+    let(:resource) { resource_class.new }
+
+    it { is_expected.to respond_to(:save).with_keywords(:resource) }
+    it { is_expected.to respond_to(:save_all).with_keywords(:resources) }
+    it { is_expected.to respond_to(:delete).with_keywords(:resource) }
+
+    it "can save a resource" do
+      expect(persister.save(resource: resource)).to eq true
+    end
+
+    it "can save multiple resources at once" do
+      resource2 = resource_class.new
+      results = persister.save_all(resources: [resource, resource2])
+      expect(results).to eq true
+    end
+  end
+end

--- a/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
@@ -17,5 +17,29 @@ RSpec.describe Valkyrie::Persistence::Solr::MetadataAdapter do
   describe "write-only mode" do
     let(:adapter) { described_class.new(connection: client, write_only: true) }
     it_behaves_like "a write-only Valkyrie::MetadataAdapter"
+    before do
+      class WriteOnlyResource < Valkyrie::Resource
+        include Valkyrie::Resource::AccessControls
+        attribute :title
+      end
+    end
+    after do
+      Object.send(:remove_const, :WriteOnlyResource)
+    end
+    it "can persist a resource" do
+      adapter.persister.wipe!
+      adapter.persister.save(resource: WriteOnlyResource.new(title: "Test Title"))
+      result = client.get("select", params: { q: "*:*" })
+
+      expect(result["response"]["numFound"]).to eq 1
+      doc = result["response"]["docs"][0]
+
+      expect(doc["title_tsim"]).to eq(["Test Title"])
+      expect(doc["title_ssim"]).to eq(["Test Title"])
+      expect(doc["title_tesim"]).to eq(["Test Title"])
+      expect(doc["title_tsi"]).to eq("Test Title")
+      expect(doc["title_ssi"]).to eq("Test Title")
+      expect(doc["title_tesi"]).to eq("Test Title")
+    end
   end
 end

--- a/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
@@ -41,5 +41,16 @@ RSpec.describe Valkyrie::Persistence::Solr::MetadataAdapter do
       expect(doc["title_ssi"]).to eq("Test Title")
       expect(doc["title_tesi"]).to eq("Test Title")
     end
+    it "can save_all" do
+      adapter.persister.wipe!
+      adapter.persister.save_all(resources: [WriteOnlyResource.new(title: "First"), WriteOnlyResource.new(title: "Second")])
+
+      result = client.get("select", params: { q: "*:*" })
+
+      expect(result["response"]["numFound"]).to eq 2
+      docs = result["response"]["docs"]
+
+      expect(docs.flat_map { |doc| doc["title_tsim"] }).to contain_exactly "First", "Second"
+    end
   end
 end

--- a/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/solr/metadata_adapter_spec.rb
@@ -13,4 +13,9 @@ RSpec.describe Valkyrie::Persistence::Solr::MetadataAdapter do
       expect(adapter.id.to_s).to eq expected
     end
   end
+
+  describe "write-only mode" do
+    let(:adapter) { described_class.new(connection: client, write_only: true) }
+    it_behaves_like "a write-only Valkyrie::MetadataAdapter"
+  end
 end


### PR DESCRIPTION
The first iteration just doesn't enforce a bunch of the shared specs and
expects a simple `true` response to save/save_all.

This adds a write_only mode to the solr persister which is a little
faster, but won't be the final state of solr indexing support.