### PR TITLE
raise a more informative NoMethodError for missing custom queries

### DIFF
--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -464,6 +464,13 @@ RSpec.shared_examples 'a Valkyrie query provider' do
     end
   end
 
+  describe ".custom_queries" do
+    it "raises NoMethodError when the custom query does not exist" do
+      expect(query_service.custom_queries).not_to respond_to :very_fake_query
+      expect { query_service.custom_queries.very_fake_query }.to raise_error(NoMethodError)
+    end
+  end
+
   describe ".register_query_handler" do
     it "can register a query handler" do
       class QueryHandler


### PR DESCRIPTION
the custom query container used to raise:

    NoMethodError: undefined method 'new' for nil:NilClass`

this error doesn't do much to help callers figure out where they've gone
awry. the updated message includes:

  - the originally called method name
  - the list of available methods to call (as a kind of 'did you mean' feature)
  - reference to the idea that queries need to be registered

hopefully these are all helpful reminders in dubugging.