### PR TITLE
Update pcdm_use.rb

### DIFF
--- a/lib/valkyrie/vocab/pcdm_use.rb
+++ b/lib/valkyrie/vocab/pcdm_use.rb
@@ -47,7 +47,7 @@ module Valkyrie::Vocab
          "rdf:subClassOf": %(http://pcdm.org/resources#File),
          "rdfs:isDefinedBy": %(pcdmuse:),
          type: "rdfs:Class"
-    warn "[DEPRECATION] PCDM is deprecating '#{self.name}#PreservationMasterFile'. Use '#{self.name}#PreservationFile' instead. " \
+    warn "[DEPRECATION] PCDM is deprecating '#{name}#PreservationMasterFile'. Use '#{name}#PreservationFile' instead. " \
          "This warning does *not* indicate that usage of the deprecated term has been detected."
     # @deprecated
     term :PreservationMasterFile,

--- a/lib/valkyrie/vocab/pcdm_use.rb
+++ b/lib/valkyrie/vocab/pcdm_use.rb
@@ -47,7 +47,8 @@ module Valkyrie::Vocab
          "rdf:subClassOf": %(http://pcdm.org/resources#File),
          "rdfs:isDefinedBy": %(pcdmuse:),
          type: "rdfs:Class"
-    warn "[DEPRECATION] PCDM is deprecating '#{self.class}#PreservationMasterFile'. Use #{self.class}#PreservationFile instead."
+    warn "[DEPRECATION] PCDM is deprecating '#{self.name}#PreservationMasterFile'. Use '#{self.name}#PreservationFile' instead. "
+         "This warning does *not* indicate that usage of the deprecated term has been detected."
     # @deprecated
     term :PreservationMasterFile,
          comment: %(Best quality representation of the Object appropriate for long-term

--- a/lib/valkyrie/vocab/pcdm_use.rb
+++ b/lib/valkyrie/vocab/pcdm_use.rb
@@ -47,7 +47,7 @@ module Valkyrie::Vocab
          "rdf:subClassOf": %(http://pcdm.org/resources#File),
          "rdfs:isDefinedBy": %(pcdmuse:),
          type: "rdfs:Class"
-    warn "[DEPRECATION] PCDM is deprecating '#{self.name}#PreservationMasterFile'. Use '#{self.name}#PreservationFile' instead. "
+    warn "[DEPRECATION] PCDM is deprecating '#{self.name}#PreservationMasterFile'. Use '#{self.name}#PreservationFile' instead. " \
          "This warning does *not* indicate that usage of the deprecated term has been detected."
     # @deprecated
     term :PreservationMasterFile,


### PR DESCRIPTION
Language of warning changed to be less confusing to downstream apps.  Printing of class name in message corrected.

This is following up on discussion in Samvera #valkyrie channel.
