### PR TITLE
support discovery of multiple disk adapters on different paths

### DIFF
--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -24,7 +24,7 @@ module Valkyrie::Storage
     # @param id [Valkyrie::ID]
     # @return [Boolean] true if this adapter can handle this type of identifer
     def handles?(id:)
-      id.to_s.start_with?("disk://")
+      id.to_s.start_with?("disk://#{base_path}")
     end
 
     def file_path(id)

--- a/spec/valkyrie/storage/disk_spec.rb
+++ b/spec/valkyrie/storage/disk_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Valkyrie::Storage::Disk do
 
   describe ".handles?" do
     it "matches on base_path" do
-      described_class.handles?(ROOT_PATH.join("tmp", "files_test")).to eq true
+      expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'files_test')}")).to eq true
     end
 
     it "does not match when base_path differs" do
-      described_class.handles?(ROOT_PATH.join("tmp", "wrong")).to eq false
+      expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
     end
   end
 end

--- a/spec/valkyrie/storage/disk_spec.rb
+++ b/spec/valkyrie/storage/disk_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe Valkyrie::Storage::Disk do
   it_behaves_like "a Valkyrie::StorageAdapter"
   let(:storage_adapter) { described_class.new(base_path: ROOT_PATH.join("tmp", "files_test")) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+  describe ".handles?" do
+    it "matches on base_path" do
+      described_class.handles?(ROOT_PATH.join("tmp", "files_test")).to eq true
+    end
+
+    it "does not match when base_path differs" do
+      described_class.handles?(ROOT_PATH.join("tmp", "wrong")).to eq false
+    end
+  end
 end


### PR DESCRIPTION
when using multiple disk adapters targeting different `base_path`s on the local
disk, `Valkyrie::StorageAdapter.adapter_for(id: 'disk:///some/path/image.jpg')`
should match against the adapter handling `/some/path`. the original
implementation used whichever adapter was registered first chronologically.

targeting the `.handles?` implementation on `base_path` makes it possible to
resolve existing identifiers dynamically in this case.