### PR TITLE
Explicitly handle keyword arguments in queries

### DIFF
--- a/lib/valkyrie/persistence/custom_query_container.rb
+++ b/lib/valkyrie/persistence/custom_query_container.rb
@@ -47,7 +47,13 @@ module Valkyrie::Persistence
         handler = query_handler.new(query_service: query_service)
         query_handlers[query.to_sym] = handler
         define_singleton_method query do |*args, **kwargs, &block|
-          query_handlers[query.to_sym].__send__(query, *args, **kwargs, &block)
+          if kwargs.empty?
+            # This case needs to be specially handled in Ruby 2.6, or else an
+            # empty hash will be passed as the final argument.
+            query_handlers[query.to_sym].__send__(query, *args, &block)
+          else
+            query_handlers[query.to_sym].__send__(query, *args, **kwargs, &block)
+          end
         end
       end
     end

--- a/lib/valkyrie/persistence/custom_query_container.rb
+++ b/lib/valkyrie/persistence/custom_query_container.rb
@@ -46,8 +46,8 @@ module Valkyrie::Persistence
       query_handler.queries.each do |query|
         handler = query_handler.new(query_service: query_service)
         query_handlers[query.to_sym] = handler
-        define_singleton_method query do |*args, &block|
-          query_handlers[query.to_sym].__send__(query, *args, &block)
+        define_singleton_method query do |*args, **kwargs, &block|
+          query_handlers[query.to_sym].__send__(query, *args, **kwargs, &block)
         end
       end
     end

--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -495,6 +495,26 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       expect(query_service.custom_queries).to respond_to :find_by_user_id
       expect(query_service.custom_queries.find_by_user_id).to eq 1
     end
+
+    it "can register a query handler which takes keyword arguments" do
+      class QueryHandler
+        def self.queries
+          [:identity]
+        end
+
+        attr_reader :query_service
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        def identity(term:)
+          term
+        end
+      end
+      query_service.custom_queries.register_query_handler(QueryHandler)
+      expect(query_service.custom_queries).to respond_to :identity
+      expect(query_service.custom_queries.identity(term: :x)).to eq :x
+    end
   end
 
   context "optimistic locking" do


### PR DESCRIPTION
This is required for Ruby 3 compatibility:
<https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/>.