### PR TITLE
avoid using awk in shared specs

### DIFF
--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -46,7 +46,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   end
 
   def open_files
-    `lsof +D . | awk '{print $9}'`.split.uniq[1..-1]
+    `lsof +D .`.split("\n").map { |r| r.split("\t").last }
   end
 
   it "can upload, validate, re-fetch, and delete a file" do


### PR DESCRIPTION
in some contexts(?) awk can fail to filter results correctly:

```
[3] pry(RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue)> `lsof +D . | awk '{print $9}'` => "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" [4] 

pry(RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue)> `lsof +D .` => "1\t/usr/local/bin/ruby\t0\t/dev/pts/0\n1\t/usr/local/bin/ruby\t1\t/dev/pts/0\n1\t/usr/local/bin/ruby\t2\t/dev/pts/0\n1\t/usr/local/bin/ruby\t3\tanon_inode:[eventfd]\n1\t/usr/local/bin/ruby\t4\tanon_inode:[eventfd]\n1\t/usr/local/bin/ruby\t5\tpipe:[39924]\n1\t/usr/local/bin/ruby\t6\tpipe:[39924]\n1\t/usr/local/bin/ruby\t7\t/app/samvera/hyrax-engine/config/metadata/core_metadata.yaml\n1\t/usr/local/bin/ruby\t8\tanon_inode:inotify\n1\t/usr/local/bin/ruby\t9\tpipe:[39922]\n1\t/usr/local/bin/ruby\t10\tpipe:[39922]\n1\t/usr/local/bin/ruby\t11\tanon_inode:inotify\n1\t/usr/local/bin/ruby\t12\tsocket:[40809]\n1\t/usr/local/bin/ruby\t13\tpipe:[39925]\n1\t/usr/local/bin/ruby\t14\tpipe:[39925]\n1\t/usr/local/bin/ruby\t15\tpipe:[39926]\n1\t/usr/local/bin/ruby\t16\tpipe:[39926]\n1\t/usr/local/bin/ruby\t17\tanon_inode:[eventpoll]\n1\t/usr/local/bin/ruby\t18\tpipe:[39927]\n1\t/usr/local/bin/ruby\t19\tpipe:[39927]\n448\t/bin/busybox\t0\t/dev/pts/1\n448\t/bin/busybox\t1\t/dev/pts/1\n448\t/bin/busybox\t2\t/dev/pts/1\n448\t/bin/busybox\t10\t/dev/tty\n717\t/usr/local/bin/ruby\t0\t/dev/pts/2\n717\t/usr/local/bin/ruby\t1\t/dev/pts/2\n717\t/usr/local/bin/ruby\t2\t/dev/pts/2\n717\t/usr/local/bin/ruby\t3\tanon_inode:[eventfd]\n717\t/usr/local/bin/ruby\t4\tanon_inode:[eventfd]\n717\t/usr/local/bin/ruby\t5\t/app/samvera/hyrax-webapp/log/test.log\n717\t/usr/local/bin/ruby\t6\tsocket:[59017]\n717\t/usr/local/bin/ruby\t7\tsocket:[59019]\n717\t/usr/local/bin/ruby\t8\t/tmp/temp_io20230125-717-1ti353m\n717\t/usr/local/bin/ruby\t9\t/root/.local/share/pry/pry_history\n717\t/usr/local/bin/ruby\t10\tpipe:[60736]\n"
```