### PR TITLE
Removing delegate in favor of explicit method

### DIFF
--- a/lib/valkyrie/change_set.rb
+++ b/lib/valkyrie/change_set.rb
@@ -77,9 +77,11 @@ module Valkyrie
       send(key) if respond_to?(key)
     end
 
-    delegate :attributes, to: :resource
-
-    delegate :internal_resource, :created_at, :updated_at, :model_name, :optimistic_locking_enabled?, to: :resource
+    [:internal_resource, :created_at, :updated_at, :model_name, :optimistic_locking_enabled?, :attributes].each do |method_name|
+      define_method(method_name) do |*args|
+        resource.public_send(method_name, *args)
+      end
+    end
 
     # Prepopulates all fields with defaults defined in the changeset. This is an
     # override of Reform::Form's method to allow for single-valued fields to


### PR DESCRIPTION
@jeremyf [made this patch for Valkyrie 2.2](https://github.com/samvera/valkyrie/commit/0638a779fc1576f9ee74960a95d48682272f0e81); this is for 3.0.

Addresses a problem reported by @ShanaLMoore when using valkyrie with reform 0.2.4:
```/usr/local/lib/ruby/2.7.0/forwardable.rb:130:in `instance_delegate': wrong number of arguments (given 2, expected 1) (ArgumentError)```

Can be seen during a hyrax test app build [here](https://app.circleci.com/pipelines/github/samvera/hyrax/8917/workflows/f9020f5d-1d74-4710-b85e-d46fbbe4c062/jobs/68447)

Thought to be related to https://github.com/trailblazer/reform-rails/issues/99