### PR TITLE
StorageAdapter Versioning Implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
         environment:
           CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
           JAVA_OPTIONS: "-Djetty.http.port=8998 -Dfcrepo.dynamic.jms.port=61618 -Dfcrepo.dynamic.stomp.port=61614"
-      - image: fcrepo/fcrepo:6.0.0
+      - image: fcrepo/fcrepo:6.4.0
         environment:
           CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
           JAVA_OPTS: "-Djetty.http.port=8978 -Dfcrepo.dynamic.jms.port=61619 -Dfcrepo.dynamic.stomp.port=61615 -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"

--- a/.lando.yml
+++ b/.lando.yml
@@ -51,7 +51,7 @@ services:
     volumes:
       fedora6:
     services:
-      image: fcrepo/fcrepo:6.0.0
+      image: fcrepo/fcrepo:6.4.0
       command:
         - "catalina.sh"
         - "run"

--- a/.lando.yml
+++ b/.lando.yml
@@ -24,19 +24,26 @@ services:
       - fedora4:/data
       ports:
       - 8988:8080
-    portforward: true
+    environment:
+      CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
+    portforward: 8988
   valkyrie_fedora_5:
     type: compose
     app_mount: false
     volumes:
       fedora5:
     services:
-      image: samvera/fcrepo4:5.1.0
-      command: /fedora-entrypoint.sh
+      image: fcrepo/fcrepo:5.1.1-multiplatform
+      command:
+        - "catalina.sh"
+        - "run"
       volumes:
       - fedora5:/data
       ports:
       - 8998:8080
+      environment:
+        CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
+        JAVA_OPTS: "-Dfcrepo.dynamic.jms.port=61620 -Dfcrepo.dynamic.stomp.port=61617 -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
     portforward: true
   valkyrie_fedora_6:
     type: compose

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,6 +3,7 @@ Metrics/ClassLength:
     - 'lib/valkyrie/persistence/fedora/persister.rb'
     - 'lib/valkyrie/persistence/fedora/query_service.rb'
     - 'lib/valkyrie/persistence/postgres/query_service.rb'
+    - 'lib/valkyrie/storage/fedora.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -133,6 +133,13 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(storage_adapter.find_by(id: newest_version.id).version_id).to eq newest_version.version_id
     expect(storage_adapter.find_versions(id: newest_version.id).length).to eq 3
 
+    # I can delete all versions.
+
+    storage_adapter.delete(id: newest_version.id, purge_versions: true)
+
+    expect(storage_adapter.find_versions(id: new_version.id)).to eq []
+    expect { storage_adapter.find_by(id: newest_version.version_id) }.to raise_error Valkyrie::StorageAdapter::FileNotFound
+
     # TODO
     # 1. How do I delete a version: storage_adapter.delete(id: version_id)
     # 2. Is there a way to delete all versions: storage_adapter.delete(id: id, purge_versions: true)

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
 
   it "can upload and find new versions" do
     pending "Versioning not supported" unless storage_adapter.supports?(:versions)
-    resource = Valkyrie::Specs::CustomResource.new(id: "test")
+    resource = Valkyrie::Specs::CustomResource.new(id: "test2")
     uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource, fake_upload_argument: true)
     expect(uploaded_file.version_id).not_to be_blank
 

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -16,6 +16,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   it { is_expected.to respond_to(:find_by).with_keywords(:id) }
   it { is_expected.to respond_to(:delete).with_keywords(:id) }
   it { is_expected.to respond_to(:upload).with_keywords(:file, :resource, :original_filename) }
+  it { is_expected.to respond_to(:supports?) }
 
   it "can upload a file which is just an IO" do
     io_file = Tempfile.new('temp_io')

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -140,14 +140,6 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(storage_adapter.find_versions(id: new_version.id)).to eq []
     expect { storage_adapter.find_by(id: newest_version.version_id) }.to raise_error Valkyrie::StorageAdapter::FileNotFound
 
-    # TODO
-    # 1. How do I delete a version: storage_adapter.delete(id: version_id)
-    # 2. Is there a way to delete all versions: storage_adapter.delete(id: id, purge_versions: true)
-    # 3. If I delete the root version, can I still query for its versions. Yes.
-    # 4. I can find_by a version ID and get it.
-    #
-    # Deleting: when I delete a root node, find_versions should continue to
-    # work, but find_by with the root node ID and no version ID should NotFound.
   ensure
     f&.close
   end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -96,6 +96,10 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(versions.length).to eq 2
     expect(versions.first.id).to eq new_version.id
     expect(versions.first.size).not_to eq size
+    # TODO
+    # 1. How do I delete a version
+    # 2. Is there a way to delete all versions.
+    # 3. If I delete the root version, can I still query for its versions.
   ensure
     f.close
   end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -78,4 +78,16 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect { storage_adapter.find_by(id: uploaded_file.id) }.to raise_error Valkyrie::StorageAdapter::FileNotFound
     expect { storage_adapter.find_by(id: Valkyrie::ID.new("noexist")) }.to raise_error Valkyrie::StorageAdapter::FileNotFound
   end
+
+  it "can upload and find new versions" do
+    resource = Valkyrie::Specs::CustomResource.new(id: "test")
+    uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource, fake_upload_argument: true)
+
+    new_version = storage_adapter.upload_version(file: file, original_filename: 'foo_final.jpg', previous_version_id: uploaded_file.id)
+    expect(uploaded_file.id).to eq new_version.id
+
+    versions = storage_adapter.find_versions(id: new_version.id)
+    expect(versions.length).to eq 2
+    expect(versions.first.id).to eq new_version.id
+  end
 end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -80,14 +80,23 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   end
 
   it "can upload and find new versions" do
+    pending "Versioning not supported" unless storage_adapter.supports?(:versions)
+    size = file.size
     resource = Valkyrie::Specs::CustomResource.new(id: "test")
     uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: resource, fake_upload_argument: true)
 
-    new_version = storage_adapter.upload_version(file: file, original_filename: 'foo_final.jpg', previous_version_id: uploaded_file.id)
+    f = Tempfile.new
+    f.puts "Test File"
+    f.rewind
+
+    new_version = storage_adapter.upload_version(file: f, original_filename: 'foo_final.jpg', previous_version_id: uploaded_file.id)
     expect(uploaded_file.id).to eq new_version.id
 
     versions = storage_adapter.find_versions(id: new_version.id)
     expect(versions.length).to eq 2
     expect(versions.first.id).to eq new_version.id
+    expect(versions.first.size).not_to eq size
+  ensure
+    f.close
   end
 end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -100,6 +100,15 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     # 1. How do I delete a version
     # 2. Is there a way to delete all versions.
     # 3. If I delete the root version, can I still query for its versions.
+    #
+    # Feedback: previous_version_id implies that I can upload a version of a
+    # version, not just the root.
+    #
+    # I need a current ID (get the most recent version) and every version
+    # including the current one needs a stable ID.
+    #
+    # Deleting: when I delete a root node, find_versions should continue to
+    # work, but find_by with the root node ID and no version ID should NotFound.
   ensure
     f.close
   end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -18,6 +18,10 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   it { is_expected.to respond_to(:upload).with_keywords(:file, :resource, :original_filename) }
   it { is_expected.to respond_to(:supports?) }
 
+  it "returns false for non-existing features" do
+    expect(storage_adapter.supports?(:bad_feature_not_real_dont_implement)).to eq false
+  end
+
   it "can upload a file which is just an IO" do
     io_file = Tempfile.new('temp_io')
     io_file.write "Stuff"

--- a/lib/valkyrie/storage.rb
+++ b/lib/valkyrie/storage.rb
@@ -31,6 +31,7 @@ module Valkyrie
   # @see lib/valkyrie/specs/shared_specs/storage_adapter.rb
   module Storage
     require 'valkyrie/storage/disk'
+    require 'valkyrie/storage/versioned_disk'
     require 'valkyrie/storage/fedora'
     require 'valkyrie/storage/memory'
   end

--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -27,6 +27,12 @@ module Valkyrie::Storage
       id.to_s.start_with?("disk://#{base_path}")
     end
 
+    # @param feature [Symbol] Feature to test for.
+    # @return [Boolean] true if the adapter supports the given feature
+    def supports?(_feature)
+      false
+    end
+
     def file_path(id)
       id.to_s.gsub(/^disk:\/\//, '')
     end

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -54,8 +54,9 @@ module Valkyrie::Storage
       uri = fedora_identifier(id: id)
       # Auto versioning is on, so have to sleep if it's too soon after last
       # upload.
-      if fedora_version == 6
-        return upload_version(id: id, file: file) if current_version_id(id: id).to_s.split("/").last == Time.current.utc.strftime("%Y%m%d%H%M%S")
+      if fedora_version == 6 && current_version_id(id: id).to_s.split("/").last == Time.current.utc.strftime("%Y%m%d%H%M%S")
+        sleep(0.5)
+        return upload_version(id: id, file: file)
       end
       upload_file(fedora_uri: uri, io: file)
       version_id = mint_version(uri, latest_version(uri))

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -19,6 +19,12 @@ module Valkyrie::Storage
       id.to_s.start_with?(PROTOCOL)
     end
 
+    # @param feature [Symbol] Feature to test for.
+    # @return [Boolean] true if the adapter supports the given feature
+    def supports?(_feature)
+      false
+    end
+
     # Return the file associated with the given identifier
     # @param id [Valkyrie::ID]
     # @return [Valkyrie::StorageAdapter::StreamFile]

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -88,18 +88,15 @@ module Valkyrie::Storage
 
     # Delete the file on disk associated with the given identifier.
     # @param id [Valkyrie::ID]
-    def delete(id:, purge_versions: false)
+    def delete(id:)
       base_id, version = id_and_version(id)
       if version && cache[base_id][:current]&.version_id != id
         cache[base_id][:versions].reject! do |file|
           file.version_id == id
         end
       else
-        cache[base_id][:versions] ||= []
-        cache[base_id][:versions].prepend(cache[base_id][:current])
-        cache[base_id][:current] = nil
+        cache.delete(base_id)
       end
-      cache.delete(base_id) if purge_versions
       nil
     end
   end

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -35,6 +35,12 @@ module Valkyrie::Storage
       id.to_s.start_with?("memory://")
     end
 
+    # @param feature [Symbol] Feature to test for.
+    # @return [Boolean] true if the adapter supports the given feature
+    def supports?(_feature)
+      false
+    end
+
     # Delete the file on disk associated with the given identifier.
     # @param id [Valkyrie::ID]
     def delete(id:)

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -17,7 +17,9 @@ module Valkyrie::Storage
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource: nil, **_extra_arguments)
       identifier = Valkyrie::ID.new("memory://#{resource.id}")
-      cache[identifier] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file)
+      version_id = Valkyrie::ID.new("#{identifier}##{SecureRandom.uuid}")
+      cache[identifier] ||= {}
+      cache[identifier][:current] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file, version_id: version_id)
     end
 
     # @param file [IO]
@@ -26,20 +28,20 @@ module Valkyrie::Storage
     # @param _extra_arguments [Hash] additional arguments which may be passed to
     #   other adapters.
     # @return [Valkyrie::StorageAdapter::StreamFile]
-    def upload_version(file:, original_filename:, previous_version_id:)
+    def upload_version(id:, file:)
       # Get previous file and add a UUID to the end of it.
-      previous_file = find_by(id: previous_version_id)
-      previous_file = previous_file.new(id: Valkyrie::ID.new("#{previous_version_id}##{SecureRandom.uuid}"))
-      cache[previous_file.id] = previous_file
-      cache["#{previous_version_id}_versions"] ||= []
-      cache["#{previous_version_id}_versions"] = [previous_file] + cache["#{previous_version_id}_versions"]
-      cache[previous_version_id] = Valkyrie::StorageAdapter::StreamFile.new(id: previous_version_id, io: file)
+      current_file = find_by(id: id)
+      new_file = current_file.new(io: file, version_id: Valkyrie::ID.new("#{id}##{SecureRandom.uuid}"))
+      cache[current_file.id][:current] = new_file
+      cache[current_file.id][:versions] ||= []
+      cache[current_file.id][:versions] = [current_file] + cache[current_file.id][:versions]
+      new_file
     end
 
     # @param id [Valkyrie::ID]
     # @return [Array<Valkyrie::StorageAdapter::StreamFile>]
     def find_versions(id:)
-      [find_by(id: id)] + cache.fetch("#{id}_versions", [])
+      [cache[id][:current]] + cache[id].fetch(:versions, [])
     end
 
     # Return the file associated with the given identifier
@@ -47,8 +49,15 @@ module Valkyrie::Storage
     # @return [Valkyrie::StorageAdapter::StreamFile]
     # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
     def find_by(id:)
-      raise Valkyrie::StorageAdapter::FileNotFound unless cache[id]
-      cache[id]
+      no_version_id = Valkyrie::ID.new(id.to_s.split("#").first)
+      raise Valkyrie::StorageAdapter::FileNotFound unless cache[no_version_id]
+      if id == no_version_id
+        cache[id][:current]
+      else
+        find_versions(id: no_version_id).find do |file|
+          file.version_id == id
+        end
+      end
     end
 
     # @param id [Valkyrie::ID]

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -76,6 +76,8 @@ module Valkyrie::Storage
       case feature
       when :versions
         true
+      when :version_deletion
+        true
       else
         false
       end

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -20,6 +20,20 @@ module Valkyrie::Storage
       cache[identifier] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file)
     end
 
+    # @param file [IO]
+    # @param original_filename [String]
+    # @param previous_version_id [Valkyrie::ID]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to
+    #   other adapters.
+    # @return [Valkyrie::StorageAdapter::StreamFile]
+    def upload_version(file:, original_filename:, previous_version_id:)
+      previous_file = find_by(id: previous_version_id)
+      previous_file.id = Valkyrie::ID.new("#{previous_version_id}##{SecureRandom.uuid}")
+      cache[previous_file.id] = previous_file
+      cache["#{id}_versions"] ||= []
+      cache["#{id}_versions"] = [previous_file] + cache["#{id}_versions"]
+    end
+
     # Return the file associated with the given identifier
     # @param id [Valkyrie::ID]
     # @return [Valkyrie::StorageAdapter::StreamFile]

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -41,6 +41,7 @@ module Valkyrie::Storage
     # @param id [Valkyrie::ID]
     # @return [Array<Valkyrie::StorageAdapter::StreamFile>]
     def find_versions(id:)
+      return [] if cache[id].nil?
       [cache[id][:current] || nil].compact + cache[id].fetch(:versions, [])
     end
 
@@ -87,7 +88,7 @@ module Valkyrie::Storage
 
     # Delete the file on disk associated with the given identifier.
     # @param id [Valkyrie::ID]
-    def delete(id:)
+    def delete(id:, purge_versions: false)
       base_id, version = id_and_version(id)
       if version && cache[base_id][:current]&.version_id != id
         cache[base_id][:versions].reject! do |file|
@@ -98,6 +99,7 @@ module Valkyrie::Storage
         cache[base_id][:versions].prepend(cache[base_id][:current])
         cache[base_id][:current] = nil
       end
+      cache.delete(base_id) if purge_versions
       nil
     end
   end

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -6,6 +6,11 @@ module Valkyrie::Storage
   # current file is deleted it creates a DeletionMarker, which is an empty file
   # with "deletionmarker" in the name of the file.
   class VersionedDisk
+    # A small value class that holds a version id and methods for knowing things about it.
+    # Examples of version ids in this adapter:
+    #   * "versiondisk://te/st/test/v-current-filename.jpg" (never actually saved this way on disk, just used as a reference)
+    #   * "versiondisk://te/st/test/v-1694195675462560794-filename.jpg" (this timestamped form would be saved on disk)
+    #   * "versiondisk://te/st/test/v-1694195675462560794-deletionmarker-filename.jpg" (this file is saved on disk but empty)
     class VersionId
       attr_reader :id
       def initialize(id)

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module Valkyrie::Storage
-  # Implements the DataMapper Pattern to store binary data on disk
+  # The VersionedDisk adapter implements versioned storage on disk by storing
+  # the timestamp of the file's creation as part of the file name
+  # (v-timestamp-filename.jpg). If the
+  # current file is deleted it creates a DeletionMarker, which is an empty file
+  # with "deletionmarker" in the name of the file.
   class VersionedDisk
     class VersionId
       attr_reader :id

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+module Valkyrie::Storage
+  # Implements the DataMapper Pattern to store binary data on disk
+  class VersionedDisk
+    attr_reader :base_path, :path_generator, :file_mover
+    def initialize(base_path:, path_generator: ::Valkyrie::Storage::Disk::BucketedStorage, file_mover: FileUtils.method(:mv))
+      @base_path = Pathname.new(base_path.to_s)
+      @path_generator = path_generator.new(base_path: base_path)
+      @file_mover = file_mover
+    end
+
+    # @param file [IO]
+    # @param original_filename [String]
+    # @param resource [Valkyrie::Resource]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
+    # @return [Valkyrie::StorageAdapter::File]
+    def upload(file:, original_filename:, resource: nil, **_extra_arguments)
+      version_timestamp = Time.now.to_i
+      new_path = path_generator.generate(resource: resource, file: file, original_filename: "v-#{version_timestamp}-#{original_filename}")
+      FileUtils.mkdir_p(new_path.parent)
+      file_mover.call(file.path, new_path)
+      find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))
+    end
+
+    # @param id [Valkyrie::ID]
+    # @return [Boolean] true if this adapter can handle this type of identifer
+    def handles?(id:)
+      id.to_s.start_with?("versiondisk://#{base_path}")
+    end
+
+    # @param feature [Symbol] Feature to test for.
+    # @return [Boolean] true if the adapter supports the given feature
+    def supports?(feature)
+      return true if feature == :versions
+      false
+    end
+
+    def file_path(id, version)
+      version_id(id, version).to_s.gsub(/^versiondisk:\/\//, '')
+    end
+
+    # Return the file associated with the given identifier
+    # @param id [Valkyrie::ID]
+    # @return [Valkyrie::StorageAdapter::File]
+    # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
+    def find_by(id:)
+      id, version = id_and_version(id)
+      version = get_current_version(id) if version == "current"
+      Valkyrie::StorageAdapter::File.new(id: Valkyrie::ID.new(id.to_s), io: LazyFile.open(file_path(id, version), 'rb'), version_id: version_id(id, version))
+    rescue Errno::ENOENT
+      raise Valkyrie::StorageAdapter::FileNotFound
+    end
+
+    def get_current_version(id)
+      root = Pathname.new(file_path(id, "current"))
+      original_name = root.basename.to_s.split("v-").last.split("-", 2).last
+    end
+
+    def id_and_version(id)
+      pre_version, post_version = id.to_s.split("v-")
+      version, post_version = post_version.split("-", 2)
+      [Valkyrie::ID.new("#{pre_version}v-current-#{post_version}"), version]
+    end
+
+    def version_id(id, version)
+      Valkyrie::ID.new(id.to_s.gsub("v-current", "v-#{version}"))
+    end
+
+    ## LazyFile takes File.open parameters but doesn't leave a file handle open on
+    # instantiation. This way StorageAdapter#find_by doesn't open a handle
+    # silently and never clean up after itself.
+    class LazyFile
+      def self.open(path, mode)
+        # Open the file regularly and close it, so it can error if it doesn't
+        # exist.
+        File.open(path, mode).close
+        new(path, mode)
+      end
+
+      delegate(*(File.instance_methods - Object.instance_methods), to: :_inner_file)
+
+      def initialize(path, mode)
+        @__path = path
+        @__mode = mode
+      end
+
+      def _inner_file
+        @_inner_file ||= File.open(@__path, @__mode)
+      end
+    end
+
+    # Delete the file on disk associated with the given identifier.
+    # @param id [Valkyrie::ID]
+    def delete(id:)
+      path = file_path(id)
+      FileUtils.rm_rf(path) if File.exist?(path)
+    end
+  end
+end

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -33,10 +33,10 @@ module Valkyrie::Storage
     def upload_version(id:, file:)
       version_timestamp = current_timestamp
       # Get the existing version_id so we can calculate the next path from it.
-      version_id = version_id(id)
-      version_id = version_id.version_files[1] if version_id.deletion_marker?
-      existing_path = version_id.file_path
-      new_path = Pathname.new(existing_path.gsub(version_id.version, version_timestamp.to_s))
+      current_version_id = version_id(id)
+      current_version_id = current_version_id.version_files[1] if current_version_id.deletion_marker?
+      existing_path = current_version_id.file_path
+      new_path = Pathname.new(existing_path.gsub(current_version_id.version, version_timestamp.to_s))
       FileUtils.mkdir_p(new_path.parent)
       file_mover.call(file.try(:path) || file.try(:disk_path), new_path)
       find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -48,10 +48,6 @@ module Valkyrie::Storage
         string_id.include?("v-")
       end
 
-      def file_root
-        string_id.split("v-").first
-      end
-
       def version
         string_id.split("v-").last.split("-", 2).first
       end

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -6,6 +6,104 @@ module Valkyrie::Storage
   # current file is deleted it creates a DeletionMarker, which is an empty file
   # with "deletionmarker" in the name of the file.
   class VersionedDisk
+    attr_reader :base_path, :path_generator, :file_mover
+    def initialize(base_path:, path_generator: ::Valkyrie::Storage::Disk::BucketedStorage, file_mover: FileUtils.method(:cp))
+      @base_path = Pathname.new(base_path.to_s)
+      @path_generator = path_generator.new(base_path: base_path)
+      @file_mover = file_mover
+    end
+
+    # @param file [IO]
+    # @param original_filename [String]
+    # @param resource [Valkyrie::Resource]
+    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
+    # @return [Valkyrie::StorageAdapter::File]
+    def upload(file:, original_filename:, resource: nil, **_extra_arguments)
+      version_timestamp = current_timestamp
+      new_path = path_generator.generate(resource: resource, file: file, original_filename: "v-#{version_timestamp}-#{original_filename}")
+      FileUtils.mkdir_p(new_path.parent)
+      file_mover.call(file.try(:path) || file.try(:disk_path), new_path)
+      find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))
+    end
+
+    def current_timestamp
+      Time.now.strftime("%s%N")
+    end
+
+    def upload_version(id:, file:)
+      version_timestamp = current_timestamp
+      # Get the existing version_id so we can calculate the next path from it.
+      version_id = version_id(id)
+      version_id = version_id.version_files[1] if version_id.deletion_marker?
+      existing_path = version_id.file_path
+      new_path = Pathname.new(existing_path.gsub(version_id.version, version_timestamp.to_s))
+      FileUtils.mkdir_p(new_path.parent)
+      file_mover.call(file.try(:path) || file.try(:disk_path), new_path)
+      find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))
+    end
+
+    def find_versions(id:)
+      version_files(id: id).select { |x| !x.to_s.include?("deletionmarker") }.map do |file|
+        find_by(id: Valkyrie::ID.new("versiondisk://#{file}"))
+      end
+    end
+
+    def version_files(id:)
+      root = Pathname.new(file_path(id))
+      id = VersionId.new(id)
+      root.parent.children.select { |file| file.basename.to_s.end_with?(id.filename) }.sort.reverse
+    end
+
+    # @param id [Valkyrie::ID]
+    # @return [Boolean] true if this adapter can handle this type of identifer
+    def handles?(id:)
+      id.to_s.start_with?("versiondisk://#{base_path}")
+    end
+
+    # @param feature [Symbol] Feature to test for.
+    # @return [Boolean] true if the adapter supports the given feature
+    def supports?(feature)
+      return true if feature == :versions || feature == :version_deletion
+      false
+    end
+
+    def file_path(version_id)
+      version_id.to_s.gsub(/^versiondisk:\/\//, '')
+    end
+
+    # Return the file associated with the given identifier
+    # @param id [Valkyrie::ID]
+    # @return [Valkyrie::StorageAdapter::File]
+    # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
+    def find_by(id:)
+      version_id = version_id(id)
+      raise Valkyrie::StorageAdapter::FileNotFound if version_id.nil? || version_id&.deletion_marker?
+      Valkyrie::StorageAdapter::File.new(id: version_id.current_reference_id.id, io: ::Valkyrie::Storage::Disk::LazyFile.open(version_id.file_path, 'rb'), version_id: version_id.id)
+    rescue Errno::ENOENT
+      raise Valkyrie::StorageAdapter::FileNotFound
+    end
+
+    # @return VersionId A VersionId value that's resolved a current reference,
+    #   so we can access the `version_id` and current reference.
+    def version_id(id)
+      id = VersionId.new(id)
+      return id unless id.versioned?
+      id.resolve_current
+    end
+
+    # Delete the file on disk associated with the given identifier.
+    # @param id [Valkyrie::ID]
+    def delete(id:, purge_versions: false)
+      id = version_id(id).resolve_current
+      if id.current?
+        id.version_files.each do |version_id|
+          FileUtils.rm_rf(version_id.file_path)
+        end
+      elsif File.exist?(id.file_path)
+        FileUtils.rm_rf(id.file_path)
+      end
+    end
+
     # A small value class that holds a version id and methods for knowing things about it.
     # Examples of version ids in this adapter:
     #   * "versiondisk://te/st/test/v-current-filename.jpg" (never actually saved this way on disk, just used as a reference)
@@ -65,100 +163,6 @@ module Valkyrie::Storage
 
       def string_id
         id.to_s
-      end
-    end
-    attr_reader :base_path, :path_generator, :file_mover
-    def initialize(base_path:, path_generator: ::Valkyrie::Storage::Disk::BucketedStorage, file_mover: FileUtils.method(:cp))
-      @base_path = Pathname.new(base_path.to_s)
-      @path_generator = path_generator.new(base_path: base_path)
-      @file_mover = file_mover
-    end
-
-    # @param file [IO]
-    # @param original_filename [String]
-    # @param resource [Valkyrie::Resource]
-    # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
-    # @return [Valkyrie::StorageAdapter::File]
-    def upload(file:, original_filename:, resource: nil, **_extra_arguments)
-      version_timestamp = current_timestamp
-      new_path = path_generator.generate(resource: resource, file: file, original_filename: "v-#{version_timestamp}-#{original_filename}")
-      FileUtils.mkdir_p(new_path.parent)
-      file_mover.call(file.try(:path) || file.try(:disk_path), new_path)
-      find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))
-    end
-
-    def current_timestamp
-      Time.now.strftime("%s%N")
-    end
-
-    def upload_version(id:, file:)
-      version_timestamp = current_timestamp
-      version_id = version_id(id)
-      version_id = version_id.version_files[1] if version_id.deletion_marker?
-      existing_path = version_id.file_path
-      new_path = Pathname.new(existing_path.gsub(version_id.version, version_timestamp.to_s))
-      FileUtils.mkdir_p(new_path.parent)
-      file_mover.call(file.try(:path) || file.try(:disk_path), new_path)
-      find_by(id: Valkyrie::ID.new("versiondisk://#{new_path}"))
-    end
-
-    def find_versions(id:)
-      version_files(id: id).select { |x| !x.to_s.include?("deletionmarker") }.map do |file|
-        find_by(id: Valkyrie::ID.new("versiondisk://#{file}"))
-      end
-    end
-
-    def version_files(id:)
-      root = Pathname.new(file_path(id))
-      id = VersionId.new(id)
-      root.parent.children.select { |file| file.basename.to_s.end_with?(id.filename) }.sort.reverse
-    end
-
-    # @param id [Valkyrie::ID]
-    # @return [Boolean] true if this adapter can handle this type of identifer
-    def handles?(id:)
-      id.to_s.start_with?("versiondisk://#{base_path}")
-    end
-
-    # @param feature [Symbol] Feature to test for.
-    # @return [Boolean] true if the adapter supports the given feature
-    def supports?(feature)
-      return true if feature == :versions || feature == :version_deletion
-      false
-    end
-
-    def file_path(version_id)
-      version_id.to_s.gsub(/^versiondisk:\/\//, '')
-    end
-
-    # Return the file associated with the given identifier
-    # @param id [Valkyrie::ID]
-    # @return [Valkyrie::StorageAdapter::File]
-    # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
-    def find_by(id:)
-      version_id = version_id(id)
-      raise Valkyrie::StorageAdapter::FileNotFound if version_id.nil? || version_id&.deletion_marker?
-      Valkyrie::StorageAdapter::File.new(id: version_id.current_reference_id.id, io: ::Valkyrie::Storage::Disk::LazyFile.open(version_id.file_path, 'rb'), version_id: version_id.id)
-    rescue Errno::ENOENT
-      raise Valkyrie::StorageAdapter::FileNotFound
-    end
-
-    def version_id(id)
-      id = VersionId.new(id)
-      return id unless id.versioned?
-      id.resolve_current
-    end
-
-    # Delete the file on disk associated with the given identifier.
-    # @param id [Valkyrie::ID]
-    def delete(id:, purge_versions: false)
-      id = version_id(id).resolve_current
-      if id.current?
-        id.version_files.each do |version_id|
-          FileUtils.rm_rf(version_id.file_path)
-        end
-      elsif File.exist?(id.file_path)
-        FileUtils.rm_rf(id.file_path)
       end
     end
   end

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -16,6 +16,7 @@ module Valkyrie::Storage
         self.class.new(Valkyrie::ID.new(string_id.gsub(version, "current")))
       end
 
+      # @return [VersionID] the version_id for the current file
       def resolve_current
         return self unless reference?
         version_files.first

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -116,7 +116,7 @@ module Valkyrie::Storage
     # @param feature [Symbol] Feature to test for.
     # @return [Boolean] true if the adapter supports the given feature
     def supports?(feature)
-      return true if feature == :versions
+      return true if feature == :versions || feature == :version_deletion
       false
     end
 

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -41,6 +41,7 @@ module Valkyrie::Storage
         version_files.first.id == id
       end
 
+      # @return [Boolean] Whether this id is referential (e.g. "current") or absolute (e.g. a timestamp)
       def reference?
         version == "current"
       end

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -80,7 +80,7 @@ module Valkyrie::Storage
 
     # Delete the file on disk associated with the given identifier.
     # @param id [Valkyrie::ID]
-    def delete(id:, purge_versions: false)
+    def delete(id:)
       id = version_id(id).resolve_current
       if id.current?
         id.version_files.each do |version_id|

--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -67,6 +67,7 @@ module Valkyrie
     class File < Dry::Struct
       attribute :id, Valkyrie::Types::Any
       attribute :io, Valkyrie::Types::Any
+      attribute :version_id, Valkyrie::Types::Any.optional.default(nil)
       delegate :size, :read, :rewind, :close, to: :io
       def stream
         io

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "valkyrie"
 require 'pry'
+require 'pry-byebug'
 require 'action_dispatch'
 require 'webmock/rspec'
 require 'timecop'

--- a/spec/support/fedora_helper.rb
+++ b/spec/support/fedora_helper.rb
@@ -9,7 +9,7 @@ module FedoraHelper
     elsif fedora_version == 6
       port = ENV["FEDORA_6_PORT"] || 8978
     end
-    connection_url = fedora_version == 6 ? "/fcrepo/rest" : "/rest"
+    connection_url = fedora_version == 6 || (fedora_version == 5 && !ENV["CI"]) ? "/fcrepo/rest" : "/rest"
     opts = {
       base_path: base_path,
       connection: ::Ldp::Client.new(faraday_client("http://#{fedora_auth}localhost:#{port}#{connection_url}")),

--- a/spec/valkyrie/storage/disk_spec.rb
+++ b/spec/valkyrie/storage/disk_spec.rb
@@ -17,4 +17,8 @@ RSpec.describe Valkyrie::Storage::Disk do
       expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
     end
   end
+
+  # TODO: Add a toggle to enable versioning.
+  # Think more about what happens if someone turns versioning on for an existing
+  # repository.
 end

--- a/spec/valkyrie/storage/disk_spec.rb
+++ b/spec/valkyrie/storage/disk_spec.rb
@@ -17,8 +17,4 @@ RSpec.describe Valkyrie::Storage::Disk do
       expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
     end
   end
-
-  # TODO: Add a toggle to enable versioning.
-  # Think more about what happens if someone turns versioning on for an existing
-  # repository.
 end

--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
           let(:storage_adapter) { described_class.new(**fedora_adapter_config(base_path: 'test', fedora_version: 5)) }
 
           it 'produces a valid URI' do
-            expected_uri = 'fedora://localhost:8998/rest/test/AN1D4UHA/original'
+            expected_uri = "fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/test/AN1D4UHA/original"
             expect(uploaded_file.id.to_s).to eq expected_uri
           end
         end
@@ -103,7 +103,7 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
           let(:storage_adapter) { described_class.new(**fedora_adapter_config(base_path: '/', fedora_version: 5)) }
 
           it 'produces a valid URI' do
-            expected_uri = RDF::URI.new('fedora://localhost:8998/rest/AN1D4UHA/original')
+            expected_uri = RDF::URI.new("fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/AN1D4UHA/original")
             expect(uploaded_file.id.to_s).to eq expected_uri
           end
         end
@@ -131,7 +131,7 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
         let(:storage_adapter) { described_class.new(**fedora_adapter_config(base_path: 'test', fedora_version: 5)) }
 
         it 'produces a valid URI' do
-          expected_uri = 'fedora://localhost:8998/rest/test/AN/1D/4U/HA/AN1D4UHA/original'
+          expected_uri = "fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/test/AN/1D/4U/HA/AN1D4UHA/original"
           expect(uploaded_file.id.to_s).to eq expected_uri
         end
       end

--- a/spec/valkyrie/storage/versioned_disk_spec.rb
+++ b/spec/valkyrie/storage/versioned_disk_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'valkyrie/specs/shared_specs'
+include ActionDispatch::TestProcess
+
+RSpec.describe Valkyrie::Storage::VersionedDisk do
+  it_behaves_like "a Valkyrie::StorageAdapter"
+  let(:storage_adapter) { described_class.new(base_path: ROOT_PATH.join("tmp", "files_test")) }
+  let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+  describe ".handles?" do
+    it "matches on base_path" do
+      expect(storage_adapter.handles?(id: "versiondisk://#{ROOT_PATH.join('tmp', 'files_test')}")).to eq true
+    end
+
+    it "does not match when base_path differs" do
+      expect(storage_adapter.handles?(id: "versiondisk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
+    end
+  end
+end

--- a/spec/valkyrie/storage/versioned_disk_spec.rb
+++ b/spec/valkyrie/storage/versioned_disk_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Valkyrie::Storage::VersionedDisk do
   it_behaves_like "a Valkyrie::StorageAdapter"
   let(:storage_adapter) { described_class.new(base_path: ROOT_PATH.join("tmp", "files_test")) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  before do
+    FileUtils.rm_rf(ROOT_PATH.join("tmp", "files_test"))
+  end
 
   describe ".handles?" do
     it "matches on base_path" do


### PR DESCRIPTION
This adds a versioning implementation to Valkyrie StorageAdapters and implements it for a new versioned disk adapter and Fedora 4/5/6.

There's a follow-on ticket to do here: https://github.com/samvera/valkyrie/issues/934

As this doesn't change the API or outcomes of any of the adapters this is a minor release.