### PR TITLE
Add support for coercible symbols in the Fedora persister

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister/model_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/model_converter.rb
@@ -538,6 +538,25 @@ module Valkyrie::Persistence::Fedora
           CompositeProperty.new(new_values)
         end
       end
+
+      # Class for mapping Property objects for Symbol values
+      class SymbolValue < MappedFedoraValue
+        FedoraValue.register(self)
+
+        # Determines whether or not the value is a Property for Symbol values
+        # @param [Object] value
+        # @return [Boolean]
+        def self.handles?(value)
+          value.is_a?(Property) && value.value.is_a?(Symbol)
+        end
+
+        # Generates the Property for the Symbol value
+        # The Symbol value is converted into a String
+        # @return [Valkyrie::Persistence::Fedora::Persister::ModelConverter::Property]
+        def result
+          map_value(converted_value: value.value.to_s)
+        end
+      end
     end
   end
 end

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -64,6 +64,31 @@ RSpec.describe Valkyrie::Persistence::Fedora::Persister, :wipe_fedora do
         end
       end
 
+      context "when given a Symbol" do
+        before do
+          raise 'persister must be set with `let(:persister)`' unless defined? persister
+          class CustomResource < Valkyrie::Resource
+            attribute :mode, Valkyrie::Types::Coercible::Symbol
+          end
+        end
+
+        after do
+          Object.send(:remove_const, :CustomResource)
+        end
+
+        let(:resource_class) { CustomResource }
+
+        it "works" do
+          id = Valkyrie::ID.new("test/symbol")
+          resource = resource_class.new(id: id, mode: :read)
+          persister.save(resource: resource)
+
+          resource = query_service.find_by(id: id)
+          expect(resource).to be_persisted
+          expect(resource.mode).to eq :read
+        end
+      end
+
       context "when given an alternate identifier" do
         before do
           raise 'persister must be set with `let(:persister)`' unless defined? persister


### PR DESCRIPTION
### Problem

I am currently working on fixing some permission issues in a Hyrax/Fedora 6 setup using the Valkyrie Fedora adapter. The underlying issue is tied to the `Hyrax::Permission`  `:mode`  attribute, which is of type `Valkyrie::Types::Coercible::Symbol` , not saving correctly on Fedora 6 using the Valkyrie adapter.

### Proposed Solution

Since the type we are trying to support is `Valkyrie::Types::Coercible::Symbol`, identifying `Symbol` values in the `ModelConverter` of the Fedora Persister and converting them to `String` values resolves the issues we are encountering.