### PR TITLE
Add #version to storage adapters

### DIFF
--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -69,6 +69,8 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(uploaded_file.valid?(size: (size + 1), digests: { sha1: sha1 })).to be false
     expect(uploaded_file.valid?(size: size, digests: { sha1: 'bogus' })).to be false
 
+    expect(storage_adapter.version(id: uploaded_file.id)).to be_instance_of String
+
     expect(storage_adapter.handles?(id: uploaded_file.id)).to eq true
     file = storage_adapter.find_by(id: uploaded_file.id)
     expect(file.id).to eq uploaded_file.id

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -15,6 +15,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
   it { is_expected.to respond_to(:handles?).with_keywords(:id) }
   it { is_expected.to respond_to(:find_by).with_keywords(:id) }
   it { is_expected.to respond_to(:delete).with_keywords(:id) }
+  it { is_expected.to respond_to(:version).with_keywords(:id) }
   it { is_expected.to respond_to(:upload).with_keywords(:file, :resource, :original_filename) }
   it { is_expected.to respond_to(:supports?) }
 
@@ -106,9 +107,11 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(versions.length).to eq 2
     expect(versions.first.id).to eq new_version.id
     expect(versions.first.version_id).to eq new_version.version_id
+    expect(new_version.version_id.to_s).to include storage_adapter.version(id: versions.first.version_id)
 
     expect(versions.last.id).to eq uploaded_file.id
     expect(versions.last.version_id).to eq uploaded_file.version_id
+    expect(uploaded_file.version_id.to_s).to include storage_adapter.version(id: versions.last.version_id)
 
     expect(versions.first.size).not_to eq versions.last.size
 

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -69,11 +69,10 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(uploaded_file.valid?(size: (size + 1), digests: { sha1: sha1 })).to be false
     expect(uploaded_file.valid?(size: size, digests: { sha1: 'bogus' })).to be false
 
-    expect(storage_adapter.version(id: uploaded_file.id)).to be_instance_of String
-
     expect(storage_adapter.handles?(id: uploaded_file.id)).to eq true
     file = storage_adapter.find_by(id: uploaded_file.id)
     expect(file.id).to eq uploaded_file.id
+    expect(file.version_id.to_s).to include storage_adapter.version(id: file.id)
     expect(file).to respond_to(:stream).with(0).arguments
     expect(file).to respond_to(:read).with(0).arguments
     expect(file).to respond_to(:rewind).with(0).arguments

--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -77,6 +77,12 @@ module Valkyrie::Storage
       FileUtils.rm_rf(path) if File.exist?(path)
     end
 
+    # Versioning is unsupported, version is always "current"
+    # @param id [Valkyrie::ID]
+    def version(id:)
+      'current'
+    end
+
     class BucketedStorage
       attr_reader :base_path
       def initialize(base_path:)

--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -42,7 +42,9 @@ module Valkyrie::Storage
     # @return [Valkyrie::StorageAdapter::File]
     # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
     def find_by(id:)
-      Valkyrie::StorageAdapter::File.new(id: Valkyrie::ID.new(id.to_s), io: LazyFile.open(file_path(id), 'rb'))
+      Valkyrie::StorageAdapter::File.new(id: Valkyrie::ID.new(id.to_s),
+                                         io: LazyFile.open(file_path(id), 'rb'),
+                                         version_id: version(id: id))
     rescue Errno::ENOENT
       raise Valkyrie::StorageAdapter::FileNotFound
     end

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -86,6 +86,16 @@ module Valkyrie::Storage
       connection.http.delete(fedora_identifier(id: id))
     end
 
+    # Return only the version portion of the given identifier
+    # If version cannot be determined, assume it is current.
+    # @param id [Valkyrie::ID]
+    def version(id:)
+      raise ArgumentError('id cannot be nil') if id.nil? # escapes recursive call in case version_list is blank
+      id.to_s.match(/fcr:versions\/(\w+)/) do |m|
+        m[1]
+      end || version(id: current_version_id(id: id))
+    end
+
     def version_list(fedora_uri)
       version_list = connection.http.get do |request|
         request.url "#{fedora_uri}/fcr:versions"

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -88,6 +88,12 @@ module Valkyrie::Storage
       [Valkyrie::ID.new(id), version]
     end
 
+    # Return only the version portion of the given identifier
+    # @param id [Valkyrie::ID]
+    def version(id:)
+      id_and_version(id).last
+    end
+
     # Delete the file on disk associated with the given identifier.
     # @param id [Valkyrie::ID]
     def delete(id:)

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -91,7 +91,7 @@ module Valkyrie::Storage
     # Return only the version portion of the given identifier
     # @param id [Valkyrie::ID]
     def version(id:)
-      id_and_version(id).last
+      id_and_version(find_by(id: id).version_id).last
     end
 
     # Delete the file on disk associated with the given identifier.

--- a/lib/valkyrie/storage/versioned_disk.rb
+++ b/lib/valkyrie/storage/versioned_disk.rb
@@ -91,6 +91,13 @@ module Valkyrie::Storage
       end
     end
 
+    # Return only the version portion of the given identifier.
+    # If version cannot be determined, assume it is current.
+    # @param id [Valkyrie::ID]
+    def version(id:)
+      version_id(id).version
+    end
+
     # @param id [Valkyrie::ID]
     # @return [Array<Valkyrie::StorageAdapter::File>]
     def find_versions(id:)

--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -51,6 +51,14 @@ module Valkyrie
         adapter_for(id: id).delete(id: id)
       end
 
+      # Search through all registered storage adapters until it finds one that
+      # can handle the passed in identifier.  Then call version on that adapter
+      # with the given identifier.
+      # @param id [Valkyrie::ID]
+      def version(id:)
+        adapter_for(id: id).version(id: id)
+      end
+
       # Return the registered storage adapter which handles the given ID.
       # @param id [Valkyrie::ID]
       # @return [Valkyrie::StorageAdapter]

--- a/spec/valkyrie/storage_adapter_spec.rb
+++ b/spec/valkyrie/storage_adapter_spec.rb
@@ -63,4 +63,16 @@ RSpec.describe Valkyrie::StorageAdapter do
       expect(storage_adapter).to have_received(:delete).with(id: "yo")
     end
   end
+
+  describe ".version" do
+    it "calls version on the matching identifier" do
+      file = instance_double(Valkyrie::StorageAdapter::StreamFile, id: "yo")
+      allow(storage_adapter).to receive(:handles?).and_return(true)
+      allow(storage_adapter).to receive(:version)
+      described_class.register(storage_adapter, :find_test)
+
+      described_class.version(id: file.id)
+      expect(storage_adapter).to have_received(:version).with(id: "yo")
+    end
+  end
 end


### PR DESCRIPTION
### Rationale
An application should not need to know the implementation details of each storage adapter to discover what version a given file is. Version info is helpful when Hyrax builds a iiif manifest that includes version identifiers in the image ids.

### Notes
- For ease of use, the disk adapter always returns "current".
- If a nonversioned id is given then an attempt is made to return the version of the current version.

