### PR TITLE
♻️ Favor Engine's root path instead of ROOT_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming
+
+* Remove spec dependency on `ROOT_PATH` and favor `Valkyrie::Engine.root`
+  instead.  Thus allowing downstream implementations to leverage the fixtures in
+  Valkyrie. ([jeremyf](https://github.com/jeremyf))
+  
 # v3.1.1 2023-10-05
 
 ## Changes since last release

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     # WebMock prevents the request from using send_request_with_body_stream as it can do IRL
     WebMock.disable!
     allow(storage_adapter).to receive(:file_mover).and_return(FileUtils.method(:cp))
-    File.open(ROOT_PATH.join("spec", "fixtures", "files", "tn_example.jpg")) do |io_file|
+    File.open(Valkyrie::Engine.root.join("spec", "fixtures", "files", "tn_example.jpg")) do |io_file|
       sha1 = Digest::SHA1.file(io_file).to_s
 
       resource = Valkyrie::Specs::CustomResource.new(id: SecureRandom.uuid)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ SimpleCov.start do
 end
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "valkyrie"
+require "valkyrie/engine"
 require 'pry'
 require 'pry-byebug'
 require 'action_dispatch'
@@ -19,7 +20,6 @@ require 'timecop'
 
 SOLR_TEST_URL = "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8994}/solr/valkyrie-core-test"
 
-ROOT_PATH = Pathname.new(Dir.pwd)
 Dir[Pathname.new("./").join("spec", "support", "**", "*.rb")].sort.each { |file| require_relative file.gsub(/^spec\//, "") }
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/support/fixture_path.rb
+++ b/spec/support/fixture_path.rb
@@ -16,5 +16,5 @@ RSpec.configure do |config|
   config.add_setting :fixture_path
   config.extend FixturePath
   config.include FixturePath
-  config.fixture_path = "#{ROOT_PATH}/spec/fixtures"
+  config.fixture_path = "#{Valkyrie::Engine.root}/spec/fixtures"
 end

--- a/spec/valkyrie/storage/disk_spec.rb
+++ b/spec/valkyrie/storage/disk_spec.rb
@@ -5,16 +5,16 @@ include ActionDispatch::TestProcess
 
 RSpec.describe Valkyrie::Storage::Disk do
   it_behaves_like "a Valkyrie::StorageAdapter"
-  let(:storage_adapter) { described_class.new(base_path: ROOT_PATH.join("tmp", "files_test")) }
+  let(:storage_adapter) { described_class.new(base_path: Valkyrie::Engine.root.join("tmp", "files_test")) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
 
   describe ".handles?" do
     it "matches on base_path" do
-      expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'files_test')}")).to eq true
+      expect(storage_adapter.handles?(id: "disk://#{Valkyrie::Engine.root.join('tmp', 'files_test')}")).to eq true
     end
 
     it "does not match when base_path differs" do
-      expect(storage_adapter.handles?(id: "disk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
+      expect(storage_adapter.handles?(id: "disk://#{Valkyrie::Engine.root.join('tmp', 'wrong')}")).to eq false
     end
   end
 end

--- a/spec/valkyrie/storage/versioned_disk_spec.rb
+++ b/spec/valkyrie/storage/versioned_disk_spec.rb
@@ -5,19 +5,19 @@ include ActionDispatch::TestProcess
 
 RSpec.describe Valkyrie::Storage::VersionedDisk do
   it_behaves_like "a Valkyrie::StorageAdapter"
-  let(:storage_adapter) { described_class.new(base_path: ROOT_PATH.join("tmp", "files_test")) }
+  let(:storage_adapter) { described_class.new(base_path: Valkyrie::Engine.root.join("tmp", "files_test")) }
   let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
   before do
-    FileUtils.rm_rf(ROOT_PATH.join("tmp", "files_test"))
+    FileUtils.rm_rf(Valkyrie::Engine.root.join("tmp", "files_test"))
   end
 
   describe ".handles?" do
     it "matches on base_path" do
-      expect(storage_adapter.handles?(id: "versiondisk://#{ROOT_PATH.join('tmp', 'files_test')}")).to eq true
+      expect(storage_adapter.handles?(id: "versiondisk://#{Valkyrie::Engine.root.join('tmp', 'files_test')}")).to eq true
     end
 
     it "does not match when base_path differs" do
-      expect(storage_adapter.handles?(id: "versiondisk://#{ROOT_PATH.join('tmp', 'wrong')}")).to eq false
+      expect(storage_adapter.handles?(id: "versiondisk://#{Valkyrie::Engine.root.join('tmp', 'wrong')}")).to eq false
     end
   end
 end

--- a/spec/valkyrie/storage_adapter/file_spec.rb
+++ b/spec/valkyrie/storage_adapter/file_spec.rb
@@ -4,7 +4,7 @@ require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::StorageAdapter::File do
   let(:io) do
-    File.open(ROOT_PATH.join("spec", "fixtures", "files", "example.tif"))
+    File.open(Valkyrie::Engine.root.join("spec", "fixtures", "files", "example.tif"))
   end
   let(:file) { described_class.new(id: "test_file", io: io) }
   it_behaves_like "a Valkyrie::StorageAdapter::File"

--- a/spec/valkyrie_spec.rb
+++ b/spec/valkyrie_spec.rb
@@ -39,7 +39,7 @@ describe Valkyrie do
       end
     end
     it "uses that path" do
-      allow(Rails).to receive(:root).and_return(ROOT_PATH)
+      allow(Rails).to receive(:root).and_return(Valkyrie::Engine.root)
       allow(Rails).to receive(:env).and_return("test")
 
       described_class.instance_variable_set(:@config, nil)


### PR DESCRIPTION
This allows for downstream implementations to not require setting a `ROOT_PATH` constant—one that is general in name—in specs.