### PR TITLE
🐛 Include spec/fixture files as part of gem

### DIFF
--- a/valkyrie.gemspec
+++ b/valkyrie.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |spec|
   spec.metadata      = { "rubygems_mfa_required" => "true" }
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    # Due to the construction of shared specs, we want to include the fixtures.
+    f.match(%r{^(test|spec|features)}) && !f.start_with?('spec/fixtures')
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Given that the shared specs reference spec/fixtures, and those shared specs are used by downstream implementations, we need to ensure that the spec/fixtures are part of the Gemfile.

This problem was brought further to light by the following PR:

- https://github.com/samvera/valkyrie/pull/942

Prior to #942's introducing, each downstream implementation needed to create a `ROOT_PATH` constant to leverage the shared specs AND provide their own spec/fixtures.

To verify this logic, I checked the command line:

```ruby
irb> files = `git ls-files -z`.split("\x0").reject do |f|
       f.match(%r{^(test|spec|features)}) && !f.start_with?("spec/fixtures")
     end
=> [".circleci/config.yml",
   ...
irb> files.size
144
irb> files.map { |f| f.split("/")[0..1].join("/") }.uniq
=>
[".circleci/config.yml",
 ".ctags",
 ".gitignore",
 ".lando.yml",
 ".rspec",
 ".rubocop.yml",
 ".rubocop_todo.yml",
 ".tool-versions",
 "Appraisals",
 "CHANGELOG.md",
 "CODE_OF_CONDUCT.md",
 "CONTRIBUTING.md",
 "Gemfile",
 "LICENSE",
 "README.md",
 "Rakefile",
 "SUPPORT.md",
 "bin/console",
 "bin/jetty_wait",
 "bin/rspec",
 "bin/setup",
 "browserslist",
 "config/valkyrie.yml",
 "db/config.yml",
 "db/migrate",
 "db/schema.rb",
 "gemfiles/activerecord_5_2.gemfile",
 "gemfiles/activerecord_6_0.gemfile",
 "gemfiles/activerecord_7_0.gemfile",
 "gemfiles/faraday_0.gemfile",
 "gemfiles/faraday_1.gemfile",
 "lib/valkyrie.rb",
 "lib/valkyrie",
 "solr/config",
 "solr/solr.xml",
 "spec/fixtures",
 "tasks/dev.rake",
 "valkyrie.gemspec",
 "valkyrie_logo.png"]
```