### PR TITLE
☑️ Remove ChangeSet#prepopulate! test

### DIFF
--- a/lib/valkyrie/specs/shared_specs/change_set.rb
+++ b/lib/valkyrie/specs/shared_specs/change_set.rb
@@ -41,14 +41,6 @@ RSpec.shared_examples 'a Valkyrie::ChangeSet' do |*_flags|
     end
   end
 
-  describe "#prepopulate!" do
-    it "doesn't make it look changed" do
-      expect(change_set).not_to be_changed
-      change_set.prepopulate!
-      expect(change_set).not_to be_changed
-    end
-  end
-
   describe "#required?" do
     it "returns a boolean" do
       expect(change_set.required?(change_set.fields.keys.first)).to be_in [true, false]


### PR DESCRIPTION
This test is fragile in that it does not account for the fact that we
can specify a :prepopulate option for a property.

When you specify the `:prepopulate` option (as in
`Hyrax::Form::PcdmCollection`) and use this shared spec, then the now
deleted spec fails with no recourse.

Related to:

- https://github.com/samvera/hyrax/issues/6702
- https://github.com/samvera/hyrax/pull/6703