### PR TITLE
Add new #root_path helper

### DIFF
--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -60,6 +60,14 @@ module Valkyrie
     end
   end
 
+  def root_path
+    if Valkyrie.const_defined?(:Engine)
+      Valkyrie::Engine.root
+    else
+      Pathname.new(__dir__).dirname
+    end
+  end
+
   # @return [Valkyrie::Logging]
   def logger
     @logger ||= Valkyrie::Logging.new(logger: Logger.new(STDOUT))
@@ -123,5 +131,5 @@ module Valkyrie
     end
   end
 
-  module_function :config, :logger, :logger=, :config_root_path, :environment, :config_file, :config_hash
+  module_function :config, :logger, :logger=, :config_root_path, :environment, :config_file, :config_hash, :root_path
 end

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     # WebMock prevents the request from using send_request_with_body_stream as it can do IRL
     WebMock.disable!
     allow(storage_adapter).to receive(:file_mover).and_return(FileUtils.method(:cp))
-    File.open(Valkyrie::Engine.root.join("spec", "fixtures", "files", "tn_example.jpg")) do |io_file|
+    File.open(Valkyrie.root_path.join("spec", "fixtures", "files", "tn_example.jpg")) do |io_file|
       sha1 = Digest::SHA1.file(io_file).to_s
 
       resource = Valkyrie::Specs::CustomResource.new(id: SecureRandom.uuid)

--- a/spec/valkyrie_spec.rb
+++ b/spec/valkyrie_spec.rb
@@ -49,6 +49,21 @@ describe Valkyrie do
       expect(described_class.environment).to eq "test"
     end
   end
+  context "when Valkyrie::Engine is loaded" do
+    it "uses its root for root_path" do
+      allow(Valkyrie::Engine).to receive(:root).and_return("bla")
+
+      expect(Valkyrie.root_path).to eq "bla"
+    end
+  end
+  context "when Valkyrie::Engine is not loaded" do
+    it "uses the directory of the Valkyrie gem" do
+      allow(Valkyrie).to receive(:const_defined?).and_call_original
+      allow(Valkyrie).to receive(:const_defined?).with(:Engine).and_return(false)
+
+      expect(Valkyrie.root_path).to eq Pathname.new(Dir.pwd)
+    end
+  end
   describe ".config" do
     describe '.resource_class_resolver' do
       subject(:resolver) { described_class.config.resource_class_resolver }


### PR DESCRIPTION
Upstream gems shouldn't have to load a Rails engine or be a Rails dependency to use shared specs.