### PR TITLE
Addresses documentation issue in #951

### DIFF
--- a/lib/valkyrie/storage_adapter.rb
+++ b/lib/valkyrie/storage_adapter.rb
@@ -25,12 +25,13 @@ module Valkyrie
 
       # Find the adapter associated with the provided short name
       # @param short_name [Symbol]
-      # @return [Valkyrie::StorageAdapter]
+      # @return [Object] the storage adapter
       # @raise Valkyrie::StorageAdapter::AdapterNotFoundError when we are unable to find the named adapter
       def find(short_name)
         storage_adapters.fetch(short_name)
       rescue KeyError
-        raise "Unable to find #{self} with short_name of #{short_name.inspect}. Registered adapters are #{storage_adapters.keys.inspect}"
+        raise AdapterNotFoundError, "Unable to find #{self} with short_name of #{short_name.inspect}. " \
+                                    "Registered adapters are #{storage_adapters.keys.inspect}"
       end
 
       # Search through all registered storage adapters until it finds one that
@@ -53,7 +54,8 @@ module Valkyrie
 
       # Return the registered storage adapter which handles the given ID.
       # @param id [Valkyrie::ID]
-      # @return [Valkyrie::StorageAdapter]
+      # @return [Object] the storage adapter
+      # @raise [Valkyrie::StorageAdapter::AdapterNotFoundError]
       def adapter_for(id:)
         handler = storage_adapters.values.find do |storage_adapter|
           storage_adapter.handles?(id: id)
@@ -89,7 +91,7 @@ module Valkyrie
       end
 
       # @param size [Integer]
-      # @param digests [Array<Digest>]
+      # @param digests [Array<Hash>] array of hashes, each of which maps a digest algorithm name to a digest value.
       # @return [Boolean]
       def valid?(size: nil, digests:)
         return false if size && io.size.to_i != size.to_i

--- a/spec/valkyrie/storage_adapter_spec.rb
+++ b/spec/valkyrie/storage_adapter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Valkyrie::StorageAdapter do
   describe '.find' do
     context "with an unregistered adapter" do
       it "raises a #{described_class}::AdapterNotFoundError" do
-        expect { described_class.find(:obviously_missing) }.to raise_error(RuntimeError, /:obviously_missing/)
+        expect { described_class.find(:obviously_missing) }.to raise_error(Valkyrie::StorageAdapter::AdapterNotFoundError, /:obviously_missing/)
       end
     end
   end


### PR DESCRIPTION
Also:
- Corrects the documentation of Valkyrie::StorageAdapter::File#valid?
- Implements AdapterNotFoundError as documented on Valkyrie::StorageAdapter.find and in test description. (I'm not sure if this would technically be a breaking change since the raised exception would not be a RuntimeError.)