### PR TITLE
Support for configurable pairtree IDs in Fedora 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,39 @@ config.  If Fedora requires auth, you can also include that in the URL, e.g.:
      fedora_version: 5
    )
    ```
+#### Pairtree paths in Fedora 4/6
+Fedora 4 and 6.5+ support automatic creation of "pairtree" paths, which means that identifiers are stored in
+a hashed directory structure to avoid excessive child nodes directly in the root node.
+
+Unlike Fedora 4 where this is the default behavior, it has to be enabled via options in Fedora 6.5. This is 
+done by configuring both the count and length of the pairtree algorithm, so it needs to be configured
+in the Fedora adapters so that both sides match.
+
+In the following example, Fedora 6.5 is being started with options to create pairtree paths consisting of 
+4 segments, 2 characters in length:  
+
+```angular2html
+CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home ...
+...
+-Dfcrepo.pid.minter.length=2 -Dfcrepo.pid.minter.count=4
+```
+For the Fedora metadata/storage adapters to correctly translate identifiers into URI's, they should be initialized
+like:
+
+```angular2html
+Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+    connection: ::Ldp::Client.new("http://localhost:8080/fcrepo/rest"),
+    fedora_version: 6.5,
+    fedora_pairtree_count: 4,
+    fedora_pairtree_length: 2
+  )
+```
+
+In the configuration above, an ID of `AaBbCcDd` will be created in Fedora under the root node as `/Aa/Bb/Cc/Dd/AaBbCcDd`. 
+If count and length correctly match in the Fedora adapters, that same path will be calculated and returned.
+
+Note that the configuration above is not required for pairtree paths to work correctly in Fedora 4, and automatic
+pairtree creation is not supported under Fedora 5 or Fedora 6 < 6.5. 
 
 ## Installing a Development environment
 

--- a/spec/support/fedora_helper.rb
+++ b/spec/support/fedora_helper.rb
@@ -2,20 +2,23 @@
 require 'faraday'
 require 'faraday/multipart'
 module FedoraHelper
-  def fedora_adapter_config(base_path:, schema: nil, fedora_version: 4)
+  def fedora_adapter_config(base_path:, schema: nil, fedora_version: 4, fedora_pairtree_count: 0, # rubocop:disable Metrics/MethodLength
+                            fedora_pairtree_length: 0)
     port = 8988
     if fedora_version == 5
       port = 8998
-    elsif fedora_version == 6
+    elsif fedora_version >= 6
       port = ENV["FEDORA_6_PORT"] || 8978
     end
-    connection_url = fedora_version == 6 || (fedora_version == 5 && !ENV["CI"]) ? "/fcrepo/rest" : "/rest"
+    connection_url = fedora_version >= 6 || (fedora_version == 5 && !ENV["CI"]) ? "/fcrepo/rest" : "/rest"
     opts = {
       base_path: base_path,
       connection: ::Ldp::Client.new(faraday_client("http://#{fedora_auth}localhost:#{port}#{connection_url}")),
       fedora_version: fedora_version
     }
     opts[:schema] = schema if schema
+    opts[:fedora_pairtree_count] = fedora_pairtree_count
+    opts[:fedora_pairtree_length] = fedora_pairtree_length
     opts
   end
 

--- a/spec/valkyrie/storage/fedora_spec.rb
+++ b/spec/valkyrie/storage/fedora_spec.rb
@@ -135,6 +135,28 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
           expect(uploaded_file.id.to_s).to eq expected_uri
         end
       end
+
+      context 'when sending pairtree configuration parameters' do
+        let(:storage_adapter) do
+          described_class.new(**fedora_adapter_config(base_path: 'test', fedora_version: 5,
+                                                      fedora_pairtree_count: 4,
+                                                      fedora_pairtree_length: 2))
+        end
+        let(:uploaded_file) do
+          storage_adapter.upload(
+            file: io_file,
+            original_filename: 'foo.jpg',
+            resource: resource,
+            fake_upload_argument: true,
+            content_type: "image/tiff"
+          )
+        end
+
+        it 'is unaffected and produces expected URI' do
+          expected_uri = "fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/test/AN1D4UHA/original"
+          expect(uploaded_file.id.to_s).to eq expected_uri
+        end
+      end
     end
   end
 
@@ -200,6 +222,19 @@ RSpec.describe Valkyrie::Storage::Fedora, :wipe_fedora do
             expected_uri = RDF::URI.new("fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/AN1D4UHA/original")
             expect(uploaded_file.id.to_s).to eq expected_uri
           end
+        end
+      end
+
+      context 'when using pairtree resource uri transformer' do
+        let(:storage_adapter) do
+          described_class.new(**fedora_adapter_config(base_path: 'test', fedora_version: 6.5,
+                                                      fedora_pairtree_count: 4,
+                                                      fedora_pairtree_length: 2))
+        end
+
+        it 'produces a valid URI' do
+          expected_uri = "fedora://#{storage_adapter.connection.http.url_prefix.to_s.gsub('http://', '')}/test/AN/1D/4U/HA/AN1D4UHA/original"
+          expect(uploaded_file.id.to_s).to eq expected_uri
         end
       end
 


### PR DESCRIPTION
Fedora 6.5 now supports automatic creation of "pairtree" IDs, which means that identifiers are stored in a hashed directory structure to avoid excessive child nodes directly in the root node. 

However, unlike Fedora 4 where this was the default behavior, it has to be enabled via options in 6.5.  Since doing so requires configuring both the count and length of the pairtree algorithm, it needs to be configurable in the Valkyrie Fedora adapters so that both sides match.

This PR adds new parameters to the adapter classes to set the pairtree count and length, which are used to determine if pairtrees are enabled to affect ID to URI translations.

It carefully preserves existing behaviors as the defaults so that this is not a breaking change.  So, based on the Fedora version sent by the initializer:

- Pairtree paths for IDs are **automatically** calculated for Fedora 4
- Pairtree paths for IDs are **never** calculated for Fedora 5
- Pairtree paths for IDs are **only** calculated for Fedora 6 **if** positive values are set for count and length

