### PR TITLE
Returns nil when #id_to_uri is passed empty strings.

### DIFF
--- a/lib/valkyrie/persistence/fedora/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/fedora/metadata_adapter.rb
@@ -64,6 +64,7 @@ module Valkyrie::Persistence::Fedora
     # @param [RDF::URI] id the Valkyrie ID
     # @return [RDF::URI]
     def id_to_uri(id)
+      return if id.to_s.empty?
       prefix = ""
       prefix = "#{pair_path(id)}/" if fedora_version == 4 || (fedora_version >= 6.5 && (pairtree_count * pairtree_length).positive?)
       RDF::URI("#{connection_prefix}/#{prefix}#{CGI.escape(id.to_s)}")

--- a/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Valkyrie::Persistence::Fedora::MetadataAdapter, :wipe_fedora do
       end
 
       describe "#id_to_uri" do
+        it 'returns nil if all forms of id are empty strings' do
+          ['', Valkyrie::ID.new('')].each { |id| expect(adapter.id_to_uri(id)).to be_nil }
+        end
+
         it "converts ids with a slash" do
           id = "test/default"
           if adapter.fedora_version == 4


### PR DESCRIPTION
- lib/valkyrie/persistence/fedora/metadata_adapter.rb: stops sending empty string values to `#pair_path` and associated errors.
- spec/valkyrie/persistence/fedora/metadata_adapter_spec.rb: tests the added protective return of nil.