### PR TITLE
Fixing related URIs to account for minor versions set in fedora_version

### DIFF
--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -52,7 +52,7 @@ module Valkyrie::Persistence::Fedora
     # @return [Array<RDF::URI>]
     def include_uris
       [
-        [5, 6].include?(adapter.fedora_version) ? "http://fedora.info/definitions/fcrepo#PreferInboundReferences" : ::RDF::Vocab::Fcrepo4.InboundReferences
+        adapter.fedora_version >= 5 ? "http://fedora.info/definitions/fcrepo#PreferInboundReferences" : ::RDF::Vocab::Fcrepo4.InboundReferences
       ]
     end
 

--- a/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister/model_converter_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe Valkyrie::Persistence::Fedora::Persister::ModelConverter do
-  [4, 5, 6].each do |fedora_version|
+  [4, 5, 6, 6.5].each do |fedora_version|
     context "fedora #{fedora_version}" do
       let(:version) { fedora_version }
       let(:adapter) do

--- a/spec/valkyrie/persistence/fedora/persister_spec.rb
+++ b/spec/valkyrie/persistence/fedora/persister_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::Persister, :wipe_fedora do
-  [4, 5, 6].each do |fedora_version|
+  [4, 5, 6, 6.5].each do |fedora_version|
     context "fedora #{fedora_version}" do
       let(:version) { fedora_version }
 

--- a/spec/valkyrie/persistence/fedora/query_service_spec.rb
+++ b/spec/valkyrie/persistence/fedora/query_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Valkyrie::Persistence::Fedora::QueryService, :wipe_fedora do
-  [4, 5, 6].each do |fedora_version|
+  [4, 5, 6, 6.5].each do |fedora_version|
     context "fedora #{fedora_version}" do
       let(:version) { fedora_version }
       let(:adapter) { Valkyrie::Persistence::Fedora::MetadataAdapter.new(**fedora_adapter_config(base_path: "test_fed", fedora_version: version)) }


### PR DESCRIPTION
Support for pairtree paths in Fedora was added in #957, which was initially working per desk checking behaviors from within the Hyrax Sirenia app.  But before final approval/merge, 957 was refactored to require setting the Fedora major/minor version at 6.5 to get pairtree paths.  

When Hyrax finally picked up the 3.3.0 Valkyrie gem with pairtree support, it caused major breakage across many aspects of works and relationships.  That's because the refactor to require `fedora_version = 6.5` overlooked a bit of code in the query service that was checking major version only (5 or 6) to decide how to build related URIs.  