### PR TITLE
Adds config setting index_tsim_only_threshold

### DIFF
--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -123,7 +123,7 @@ module Valkyrie
     def defaults
       {
         resource_class_resolver: method(:default_resource_class_resolver),
-        index_tsim_only_threshold: 1000,
+        index_tsim_only_threshold: 1000
       }
     end
 

--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -97,6 +97,10 @@ module Valkyrie
       Valkyrie::StorageAdapter.find(self[:storage_adapter].to_sym)
     end
 
+    def index_tsim_only_threshold
+      self[:index_tsim_only_threshold].to_i
+    end
+
     # @api public
     #
     # The returned anonymous method (e.g. responds to #call) has a signature of
@@ -118,7 +122,8 @@ module Valkyrie
 
     def defaults
       {
-        resource_class_resolver: method(:default_resource_class_resolver)
+        resource_class_resolver: method(:default_resource_class_resolver),
+        index_tsim_only_threshold: 1000,
       }
     end
 

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -6,6 +6,8 @@ module Valkyrie::Persistence::Solr
     attr_reader :resource, :resource_factory
     delegate :resource_indexer, to: :resource_factory
 
+    INDEX_TSIM_ONLY_THRESHOLD = ENV.fetch('INDEX_TSIM_ONLY_THRESHOLD', 1000).to_i
+
     # @param [Valkyrie::Resource] resource
     # @param [ResourceFactory] resource_factory
     def initialize(resource, resource_factory:)
@@ -422,7 +424,7 @@ module Valkyrie::Persistence::Solr
       # @see https://github.com/samvera-labs/valkyrie/blob/main/solr/config/schema.xml
       # @return [Array<Symbol>]
       def fields
-        if value.value.length > 1000
+        if value.value.length > INDEX_TSIM_ONLY_THRESHOLD
           [:tsim]
         else
           [:tsim, :ssim, :tesim, :tsi, :ssi, :tesi]

--- a/lib/valkyrie/persistence/solr/model_converter.rb
+++ b/lib/valkyrie/persistence/solr/model_converter.rb
@@ -6,8 +6,6 @@ module Valkyrie::Persistence::Solr
     attr_reader :resource, :resource_factory
     delegate :resource_indexer, to: :resource_factory
 
-    INDEX_TSIM_ONLY_THRESHOLD = ENV.fetch('INDEX_TSIM_ONLY_THRESHOLD', 1000).to_i
-
     # @param [Valkyrie::Resource] resource
     # @param [ResourceFactory] resource_factory
     def initialize(resource, resource_factory:)
@@ -424,7 +422,7 @@ module Valkyrie::Persistence::Solr
       # @see https://github.com/samvera-labs/valkyrie/blob/main/solr/config/schema.xml
       # @return [Array<Symbol>]
       def fields
-        if value.value.length > INDEX_TSIM_ONLY_THRESHOLD
+        if value.value.length > Valkyrie.config.index_tsim_only_threshold
           [:tsim]
         else
           [:tsim, :ssim, :tesim, :tsi, :ssi, :tesi]

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -114,4 +114,52 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
       end
     end
   end
+
+  describe "with a long string value" do
+    let(:creator) { ("Creator " * 1000).strip }
+    let(:resource) do
+      instance_double(Resource,
+                      id: "1",
+                      internal_resource: 'Resource',
+                      title: ["Test", RDF::Literal.new("French", language: :fr)],
+                      author: ["Author"],
+                      creator: creator,
+                      attributes:
+                        {
+                          created_at: created_at,
+                          internal_resource: 'Resource',
+                          title: ["Test", RDF::Literal.new("French", language: :fr)],
+                          author: ["Author"],
+                          creator: creator
+                        })
+    end
+
+    it "only maps the long value to the _tsim Solr field" do
+      expect(mapper.convert!).to eq(
+        id: resource.id.to_s,
+        join_id_ssi: "id-#{resource.id}",
+        title_ssim: ["Test", "French"],
+        title_tesim: ["Test", "French"],
+        title_tsim: ["Test", "French"],
+        title_lang_ssim: ["eng", "fr"],
+        title_lang_tesim: ["eng", "fr"],
+        title_lang_tsim: ["eng", "fr"],
+        title_type_tsim: ["http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"],
+        title_type_ssim: ["http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"],
+        title_type_tesim: ["http://www.w3.org/1999/02/22-rdf-syntax-ns#langString", "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"],
+        author_ssim: ["Author"],
+        author_tesim: ["Author"],
+        author_tsim: ["Author"],
+        author_ssi: ["Author"],
+        author_tesi: ["Author"],
+        author_tsi: ["Author"],
+        created_at_dtsi: created_at.iso8601,
+        updated_at_dtsi: Time.current.utc.iso8601(6),
+        internal_resource_ssim: ["Resource"],
+        internal_resource_tesim: ["Resource"],
+        internal_resource_tsim: ["Resource"],
+        creator_tsim: [creator]
+      )
+    end
+  end
 end

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+># frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
@@ -132,6 +132,13 @@ RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do
                           author: ["Author"],
                           creator: creator
                         })
+    end
+
+    before do
+      Timecop.freeze
+    end
+    after do
+      Timecop.return
     end
 
     it "only maps the long value to the _tsim Solr field" do

--- a/spec/valkyrie/persistence/solr/model_converter_spec.rb
+++ b/spec/valkyrie/persistence/solr/model_converter_spec.rb
@@ -1,4 +1,4 @@
-># frozen_string_literal: true
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe Valkyrie::Persistence::Solr::ModelConverter do


### PR DESCRIPTION
To configure string length threshold above which a value is indexed only as :tsim.

Fixes #961