### PR TITLE
Provides new boolean configuration setting `auto_cast_iso8601_as_datetime'

### DIFF
--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -128,7 +128,7 @@ module Valkyrie
       {
         resource_class_resolver: method(:default_resource_class_resolver),
         index_tsim_only_threshold: 1000,
-        auto_cast_iso8601_as_datetime: true,
+        auto_cast_iso8601_as_datetime: true
       }
     end
 

--- a/lib/valkyrie.rb
+++ b/lib/valkyrie.rb
@@ -101,6 +101,10 @@ module Valkyrie
       self[:index_tsim_only_threshold].to_i
     end
 
+    def auto_cast_iso8601_as_datetime
+      self[:auto_cast_iso8601_as_datetime]
+    end
+
     # @api public
     #
     # The returned anonymous method (e.g. responds to #call) has a signature of
@@ -123,7 +127,8 @@ module Valkyrie
     def defaults
       {
         resource_class_resolver: method(:default_resource_class_resolver),
-        index_tsim_only_threshold: 1000
+        index_tsim_only_threshold: 1000,
+        auto_cast_iso8601_as_datetime: true,
       }
     end
 

--- a/lib/valkyrie/persistence/shared/json_value_mapper.rb
+++ b/lib/valkyrie/persistence/shared/json_value_mapper.rb
@@ -131,7 +131,7 @@ module Valkyrie::Persistence::Shared
 
     # Converts Date strings to `DateTime`
     class DateValue < ::Valkyrie::ValueMapper
-      PostgresValue.register(self) if ::Valkyrie.config.auto_cast_iso8601_as_datetime
+      PostgresValue.register(self)
 
       # Determines whether or not a value is an ISO 8601 datestamp String
       # e. g. 1970-01-01
@@ -139,6 +139,7 @@ module Valkyrie::Persistence::Shared
       # @return [Boolean]
       # rubocop:disable Metrics/CyclomaticComplexity
       def self.handles?(value)
+        return false unless ::Valkyrie.config.auto_cast_iso8601_as_datetime
         return false unless value.is_a?(String)
         return false unless value[4] == "-" && value[10] == "T"
         year = value.to_s[0..3]

--- a/lib/valkyrie/persistence/shared/json_value_mapper.rb
+++ b/lib/valkyrie/persistence/shared/json_value_mapper.rb
@@ -131,7 +131,7 @@ module Valkyrie::Persistence::Shared
 
     # Converts Date strings to `DateTime`
     class DateValue < ::Valkyrie::ValueMapper
-      PostgresValue.register(self) if Valkyrie.config.auto_cast_iso8601_as_datetime
+      PostgresValue.register(self) if ::Valkyrie.config.auto_cast_iso8601_as_datetime
 
       # Determines whether or not a value is an ISO 8601 datestamp String
       # e. g. 1970-01-01

--- a/lib/valkyrie/persistence/shared/json_value_mapper.rb
+++ b/lib/valkyrie/persistence/shared/json_value_mapper.rb
@@ -131,7 +131,7 @@ module Valkyrie::Persistence::Shared
 
     # Converts Date strings to `DateTime`
     class DateValue < ::Valkyrie::ValueMapper
-      PostgresValue.register(self)
+      PostgresValue.register(self) if Valkyrie.config.auto_cast_iso8601_as_datetime
 
       # Determines whether or not a value is an ISO 8601 datestamp String
       # e. g. 1970-01-01


### PR DESCRIPTION
Default value is `true` to preserve current behavior. Setting the value to `false` bypasses registration of the `DateTime` value mapper which handles the ISO8601 date/time string to Ruby DateTime casting.

Fixes #747 

Let me know if I should add a test; there are no tests for the existing functionality.