### PR TITLE
Align behavior of server managed properties with Fedora.

### DIFF
--- a/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
+++ b/lib/valkyrie/persistence/fedora/persister/orm_converter.rb
@@ -105,7 +105,8 @@ module Valkyrie::Persistence::Fedora
           # @param [Property] value
           # @return [Boolean]
           def self.handles?(value)
-            value.statement.object.to_s.start_with?("http://www.w3.org/ns/ldp", "http://fedora.info")
+            value.statement.predicate == RDF.type &&
+              value.statement.object.to_s.start_with?('http://www.w3.org/ns/ldp#', 'http://fedora.info/definitions/v4/repository#')
           end
 
           # Provide the NullApplicator Class for any Property in a deny listed namespace
@@ -562,7 +563,7 @@ module Valkyrie::Persistence::Fedora
           # @return [Array<String>]
           def denylist
             [
-              "http://fedora.info/definitions",
+              "http://fedora.info/definitions/v4/repository#",
               "http://www.iana.org/assignments/relation/last"
             ]
           end


### PR DESCRIPTION
Fixes #970 

Fedora's criteria for determining if a property is server managed has been more selective than Valkyrie's. Relevant docs and code:
https://wiki.lyrasis.org/display/FEDORA6x/Server+Managed+Triples
https://github.com/fcrepo/fcrepo/blob/1cae11d1bfb1fda3ddd39f0ab8c01f780f3c3432/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java#L74-L75

The spec is based on the needs of the Hyrax ResourceStatus service.