### PR TITLE
Check for nil id to avoid InvalidURIError

### DIFF
--- a/lib/valkyrie/persistence/fedora/query_service.rb
+++ b/lib/valkyrie/persistence/fedora/query_service.rb
@@ -162,6 +162,7 @@ module Valkyrie::Persistence::Fedora
     # @return [Valkyrie::Resource]
     # @raise [Valkyrie::Persistence::ObjectNotFoundError]
     def resource_from_uri(uri)
+      raise ::Valkyrie::Persistence::ObjectNotFoundError if uri.nil?
       resource = Ldp::Resource.for(connection, uri, connection.get(uri))
       resource_factory.to_resource(object: resource)
     rescue ::Ldp::Gone, ::Ldp::NotFound

--- a/lib/valkyrie/specs/shared_specs/queries.rb
+++ b/lib/valkyrie/specs/shared_specs/queries.rb
@@ -86,8 +86,13 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       expect { query_service.find_by(id: Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
     end
 
+    it 'returns a Valkyrie::Persistence::ObjectNotFoundError for an empty string' do
+      expect { query_service.find_by(id: '') }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+    end
+
     it 'raises an error if the id is not a Valkyrie::ID or a string' do
       expect { query_service.find_by(id: 123) }.to raise_error ArgumentError
+      expect { query_service.find_by(id: nil) }.to raise_error ArgumentError
     end
   end
 
@@ -117,8 +122,13 @@ RSpec.shared_examples 'a Valkyrie query provider' do
       expect { query_service.find_by_alternate_identifier(alternate_identifier: Valkyrie::ID.new("123123123")) }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
     end
 
+    it "raises a Valkyrie::Persistence::ObjectNotFoundError for a non-found alternate identifier" do
+      expect { query_service.find_by_alternate_identifier(alternate_identifier: '') }.to raise_error ::Valkyrie::Persistence::ObjectNotFoundError
+    end
+
     it 'raises an error if the alternate identifier is not a Valkyrie::ID or a string' do
       expect { query_service.find_by_alternate_identifier(alternate_identifier: 123) }.to raise_error ArgumentError
+      expect { query_service.find_by_alternate_identifier(alternate_identifier: nil) }.to raise_error ArgumentError
     end
 
     it 'can have multiple alternate identifiers' do


### PR DESCRIPTION
With fedora, If an empty string is passed to find_by it gets changed into a nil by id_to_uri. That nil will later cause InvalidURIError to be raised where other adapters will raise ObjectNotFound. This aligns the behavior of the fedora adapter with the others, and adds some checks in the shared spec.