### PR TITLE
Make storage adapters report their protocol string

### DIFF
--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -12,6 +12,7 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     Valkyrie::Specs.send(:remove_const, :CustomResource)
   end
   subject { storage_adapter }
+  it { is_expected.to respond_to(:protocol) }
   it { is_expected.to respond_to(:handles?).with_keywords(:id) }
   it { is_expected.to respond_to(:find_by).with_keywords(:id) }
   it { is_expected.to respond_to(:delete).with_keywords(:id) }
@@ -20,10 +21,6 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
 
   it "returns false for non-existing features" do
     expect(storage_adapter.supports?(:bad_feature_not_real_dont_implement)).to eq false
-  end
-
-  it "defines a protocol" do
-    expect(described_class::PROTOCOL).to be_a String
   end
 
   it "can upload a file which is just an IO" do

--- a/lib/valkyrie/specs/shared_specs/storage_adapter.rb
+++ b/lib/valkyrie/specs/shared_specs/storage_adapter.rb
@@ -22,6 +22,10 @@ RSpec.shared_examples 'a Valkyrie::StorageAdapter' do
     expect(storage_adapter.supports?(:bad_feature_not_real_dont_implement)).to eq false
   end
 
+  it "defines a protocol" do
+    expect(described_class::PROTOCOL).to be_a String
+  end
+
   it "can upload a file which is just an IO" do
     io_file = Tempfile.new('temp_io')
     io_file.write "Stuff"

--- a/lib/valkyrie/storage/disk.rb
+++ b/lib/valkyrie/storage/disk.rb
@@ -20,13 +20,13 @@ module Valkyrie::Storage
       new_path = path_generator.generate(resource: resource, file: file, original_filename: original_filename)
       FileUtils.mkdir_p(new_path.parent)
       file_mover.call(file.path, new_path)
-      find_by(id: Valkyrie::ID.new("#{PROTOCOL}#{new_path}"))
+      find_by(id: Valkyrie::ID.new("#{protocol}#{new_path}"))
     end
 
     # @param id [Valkyrie::ID]
     # @return [Boolean] true if this adapter can handle this type of identifer
     def handles?(id:)
-      id.to_s.start_with?("#{PROTOCOL}#{base_path}")
+      id.to_s.start_with?("#{protocol}#{base_path}")
     end
 
     # @param feature [Symbol] Feature to test for.
@@ -35,8 +35,13 @@ module Valkyrie::Storage
       false
     end
 
+    # @return [String] identifier prefix
+    def protocol
+      PROTOCOL
+    end
+
     def file_path(id)
-      id.to_s.gsub(/^#{Regexp.escape(PROTOCOL)}/, '')
+      id.to_s.gsub(/^#{Regexp.escape(protocol)}/, '')
     end
 
     # Return the file associated with the given identifier

--- a/lib/valkyrie/storage/fedora.rb
+++ b/lib/valkyrie/storage/fedora.rb
@@ -27,7 +27,7 @@ module Valkyrie::Storage
     # @param id [Valkyrie::ID]
     # @return [Boolean] true if this adapter can handle this type of identifer
     def handles?(id:)
-      id.to_s.start_with?(PROTOCOL)
+      id.to_s.start_with?(protocol)
     end
 
     # @param feature [Symbol] Feature to test for.
@@ -37,6 +37,11 @@ module Valkyrie::Storage
       # Fedora 6 auto versions and you can't delete versions.
       return true if feature == :version_deletion && fedora_version < 6
       false
+    end
+
+    # @return [String] identifier prefix
+    def protocol
+      PROTOCOL
     end
 
     # Return the file associated with the given identifier
@@ -61,7 +66,7 @@ module Valkyrie::Storage
       # Fedora 6 auto versions, so check to see if there's a version for this
       # initial upload. If not, then mint one (fedora 4/5)
       version_id = current_version_id(id: valkyrie_identifier(uri: identifier)) || mint_version(identifier, latest_version(identifier))
-      perform_find(id: Valkyrie::ID.new(identifier.to_s.sub(/^.+\/\//, PROTOCOL)), version_id: version_id)
+      perform_find(id: Valkyrie::ID.new(identifier.to_s.sub(/^.+\/\//, protocol)), version_id: version_id)
     end
 
     # @param id [Valkyrie::ID] ID of the Valkyrie::StorageAdapter::StreamFile to
@@ -77,7 +82,7 @@ module Valkyrie::Storage
       end
       upload_file(fedora_uri: uri, io: file)
       version_id = mint_version(uri, latest_version(uri))
-      perform_find(id: Valkyrie::ID.new(uri.to_s.sub(/^.+\/\//, PROTOCOL)), version_id: version_id)
+      perform_find(id: Valkyrie::ID.new(uri.to_s.sub(/^.+\/\//, protocol)), version_id: version_id)
     end
 
     # @param id [Valkyrie::ID]
@@ -197,12 +202,12 @@ module Valkyrie::Storage
     # Translate the Valkrie ID into a URL for the fedora file
     # @return [RDF::URI]
     def fedora_identifier(id:)
-      identifier = id.to_s.sub(PROTOCOL, "#{connection.http.scheme}://")
+      identifier = id.to_s.sub(protocol, "#{connection.http.scheme}://")
       RDF::URI(identifier)
     end
 
     def valkyrie_identifier(uri:)
-      id = uri.to_s.sub("http://", PROTOCOL)
+      id = uri.to_s.sub("http://", protocol)
       Valkyrie::ID.new(id)
     end
 

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -18,7 +18,7 @@ module Valkyrie::Storage
     # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource: nil, **_extra_arguments)
-      identifier = Valkyrie::ID.new("#{PROTOCOL}#{resource.id}")
+      identifier = Valkyrie::ID.new("#{protocol}#{resource.id}")
       version_id = Valkyrie::ID.new("#{identifier}##{SecureRandom.uuid}")
       cache[identifier] ||= {}
       cache[identifier][:current] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file, version_id: version_id)
@@ -69,7 +69,7 @@ module Valkyrie::Storage
     # @param id [Valkyrie::ID]
     # @return [Boolean] true if this adapter can handle this type of identifer
     def handles?(id:)
-      id.to_s.start_with?(PROTOCOL)
+      id.to_s.start_with?(protocol)
     end
 
     # @param feature [Symbol] Feature to test for.
@@ -83,6 +83,11 @@ module Valkyrie::Storage
       else
         false
       end
+    end
+
+    # @return [String] identifier prefix
+    def protocol
+      PROTOCOL
     end
 
     def id_and_version(id)

--- a/lib/valkyrie/storage/memory.rb
+++ b/lib/valkyrie/storage/memory.rb
@@ -6,6 +6,8 @@ module Valkyrie::Storage
   #   in cases where you want to preserve real data
   class Memory
     attr_reader :cache
+    PROTOCOL = 'memory://'
+
     def initialize
       @cache = {}
     end
@@ -16,7 +18,7 @@ module Valkyrie::Storage
     # @param _extra_arguments [Hash] additional arguments which may be passed to other adapters
     # @return [Valkyrie::StorageAdapter::StreamFile]
     def upload(file:, original_filename:, resource: nil, **_extra_arguments)
-      identifier = Valkyrie::ID.new("memory://#{resource.id}")
+      identifier = Valkyrie::ID.new("#{PROTOCOL}#{resource.id}")
       version_id = Valkyrie::ID.new("#{identifier}##{SecureRandom.uuid}")
       cache[identifier] ||= {}
       cache[identifier][:current] = Valkyrie::StorageAdapter::StreamFile.new(id: identifier, io: file, version_id: version_id)
@@ -67,7 +69,7 @@ module Valkyrie::Storage
     # @param id [Valkyrie::ID]
     # @return [Boolean] true if this adapter can handle this type of identifer
     def handles?(id:)
-      id.to_s.start_with?("memory://")
+      id.to_s.start_with?(PROTOCOL)
     end
 
     # @param feature [Symbol] Feature to test for.


### PR DESCRIPTION
Having this available will ease writing tests for systems that use multiple storage adapters. The fedora storage adapter already does this.

Hyrax has a couple specs that stub in file identifiers, but with fedora storage in the mix it could not find the appropriate storage adapter.